### PR TITLE
Information Architecture Overhaul

### DIFF
--- a/.claude/blog-taxonomy-guide.md
+++ b/.claude/blog-taxonomy-guide.md
@@ -1,0 +1,78 @@
+# Blog Post Taxonomy Application Guide
+
+This guide provides a systematic approach for applying categories and tags to blog posts to maintain consistency and discoverability.
+
+## Selecting a Category
+
+1. **Reference the taxonomy**: Use `@.claude/category-taxonomy.json` for the complete category taxonomy
+2. **Select best fit**: Choose the category that best applies to the post's primary focus
+3. **Suggest new categories**: If none of the existing terms apply well, suggest a new category to create
+4. **Reclassify existing posts**: If a new category is created, examine existing posts to determine if any should be reclassified
+
+### Available Categories (9 total):
+- **Technical**: Pure technical tutorials, how-tos, tool guides
+- **Learning & Challenges**: Structured learning experiences, coding challenges  
+- **Personal Growth**: Self-reflection, personal development, life lessons
+- **Projects**: Project showcases, builds, creation stories
+- **Career Development**: Professional growth, workplace skills, leadership
+- **Identity & Intersectionality**: Nuanced identity work, social systems analysis
+- **Sports & Recreation**: Physical activities, cycling, endurance sports
+- **Creative Writing**: Poetry, artistic expression
+- **Resources**: Curated collections, link roundups
+
+### Category Implementation Notes:
+- Categories with special characters use kebab-case directory names
+- Post frontmatter uses kebab-case: `categories: ['identity-and-intersectionality']`
+- Display titles are set in the category's `_index.md` file
+- Each post should have exactly one category
+
+## Selecting Tags
+
+1. **Reference the taxonomy**: Use `@.claude/tag-taxonomy.json` for the complete tag taxonomy (46 unique tags)
+2. **Select applicable tags**: Choose tags that best apply to the post content
+3. **Suggest new tags**: If additional tags would be beneficial, suggest new tags to create
+4. **Review impact**: Examine existing posts to determine if they would benefit from new tags
+5. **Confirm single-use tags**: If only one post will have a new tag, ask for explicit confirmation before proceeding
+
+### Tag Guidelines:
+- Use kebab-case format for multi-word tags
+- Technology names use proper capitalization: `JavaScript`, `TypeScript`, `GraphQL`, `CSS`, `AI`
+- Compound technical tags maintain proper capitalization: `TypeScript-generics`
+- General concept tags remain lowercase: `tooling`, `accessibility`, `learning`
+- Average 2.35 tags per post
+
+### Tag Usage Frequency:
+- **Most Used (10+ posts)**: `reflections`, `projects`, `tooling`
+- **Frequently Used (5-8 posts)**: `transgender`, `gender`, `team-health`, `accessibility`, `psychological-safety`, `react`, `functional-programming`, `learning`
+- **Moderately Used (3-4 posts)**: `TypeScript`, `personal-growth`, `today-i-learned`, etc.
+- **Less Common (1-2 posts)**: Various specialized tags
+
+## After Completion
+
+1. **Update taxonomies**: Update `tag-taxonomy.json` and `category-taxonomy.json` if new terms were added
+2. **Update documentation**: Update `CLAUDE.md` if taxonomy structure changes were made
+3. **Verify consistency**: Ensure all related posts use consistent terminology
+
+## Implementation Format
+
+### Post Frontmatter Example:
+```yaml
+---
+title: "Post Title"
+categories: ['technical']
+tags: ['react', 'TypeScript', 'testing']
+---
+```
+
+### Category Directory Structure:
+```
+content/categories/
+├── identity-and-intersectionality/
+│   └── _index.md  # Contains: title: 'Identity & Intersectionality'
+├── learning-and-challenges/
+│   └── _index.md  # Contains: title: 'Learning & Challenges'
+└── sports-and-recreation/
+    └── _index.md  # Contains: title: 'Sports & Recreation'
+```
+
+This systematic approach ensures consistent taxonomy application while maintaining flexibility for content evolution.

--- a/.claude/blog-taxonomy-guide.md
+++ b/.claude/blog-taxonomy-guide.md
@@ -35,23 +35,30 @@ This guide provides a systematic approach for applying categories and tags to bl
 5. **Confirm single-use tags**: If only one post will have a new tag, ask for explicit confirmation before proceeding
 
 ### Tag Guidelines:
+- **CRITICAL**: Never duplicate the post's category as a tag (e.g., if category is "Personal Growth", don't use "personal-growth" tag)
 - Use kebab-case format for multi-word tags
 - Technology names use proper capitalization: `JavaScript`, `TypeScript`, `GraphQL`, `CSS`, `AI`
 - Compound technical tags maintain proper capitalization: `TypeScript-generics`
 - General concept tags remain lowercase: `tooling`, `accessibility`, `learning`
-- Average 2.35 tags per post
+- Average 2.35 tags per post (aim for 2-4 tags per post)
 
 ### Tag Usage Frequency:
-- **Most Used (10+ posts)**: `reflections`, `projects`, `tooling`
+- **Most Used (10+ posts)**: `reflections`, `tooling`
 - **Frequently Used (5-8 posts)**: `transgender`, `gender`, `team-health`, `accessibility`, `psychological-safety`, `react`, `functional-programming`, `learning`
-- **Moderately Used (3-4 posts)**: `TypeScript`, `personal-growth`, `today-i-learned`, etc.
+- **Moderately Used (3-4 posts)**: `TypeScript`, `today-i-learned`, `GraphQL`, `JavaScript`, `poetry`, `retrospectives`, `react-hooks`, `gatsby`, `TypeScript-generics`, `testing`, `linting`, `community`, `creativity`, `systems-design`
 - **Less Common (1-2 posts)**: Various specialized tags
+
+### Common Tag Combinations by Category:
+- **Technical posts**: Often include `tooling`, `testing`, `linting`, specific technologies (`react`, `TypeScript`, `JavaScript`)
+- **Personal Growth posts**: Often include `reflections`, may include `learning`, `neurodiversity`, `transgender`, `gender`
+- **Projects posts**: Often include technology tags (`react`, `JavaScript`, `gatsby`), `learning`
+- **Career Development posts**: Often include `team-health`, `psychological-safety`, `leadership`, `retrospectives`
+- **Identity & Intersectionality posts**: Often include `transgender`, `gender`, may include `reflections`, `neurodiversity`
 
 ## After Completion
 
 1. **Update taxonomies**: Update `tag-taxonomy.json` and `category-taxonomy.json` if new terms were added
-2. **Update documentation**: Update `CLAUDE.md` if taxonomy structure changes were made
-3. **Verify consistency**: Ensure all related posts use consistent terminology
+2. **Verify consistency**: Ensure all related posts use consistent terminology
 
 ## Implementation Format
 

--- a/.claude/category-taxonomy.json
+++ b/.claude/category-taxonomy.json
@@ -26,7 +26,7 @@
       },
       "Learning & Challenges": {
         "description": "Structured learning experiences, coding challenges, and skill acquisition journeys",
-        "slug": "learning-challenges",
+        "slug": "learning-and-challenges",
         "post_count": 14,
         "percentage": 23.7,
         "examples": [
@@ -55,7 +55,7 @@
       },
       "Identity & Intersectionality": {
         "description": "Nuanced identity work, social systems analysis, and intersectional perspectives on society",
-        "slug": "identity-intersectionality",
+        "slug": "identity-and-intersectionality",
         "post_count": 4,
         "percentage": 5.7,
         "examples": [
@@ -111,7 +111,7 @@
       },
       "Sports & Recreation": {
         "description": "Physical activities, cycling, endurance sports, and recreational experiences",
-        "slug": "sports-recreation",
+        "slug": "sports-and-recreation",
         "post_count": 2,
         "percentage": 2.9,
         "examples": [

--- a/.claude/category-taxonomy.json
+++ b/.claude/category-taxonomy.json
@@ -1,0 +1,34 @@
+{
+  "metadata": {
+    "totalUniqueCategories": 3,
+    "totalCategoryUsages": 58,
+    "averageCategoriesPerPost": 0.85,
+    "lastUpdated": "2025-01-25",
+    "note": "Categories use title case format and are stored as arrays in frontmatter"
+  },
+  "categories": {
+    "primary": {
+      "Web Development": 42
+    },
+    "secondary": {
+      "General Musings": 14
+    },
+    "specialized": {
+      "Linked List": 2
+    },
+    "uncategorized": {
+      "empty": 1
+    }
+  },
+  "descriptions": {
+    "Web Development": "Technical posts covering programming, tools, frameworks, and development practices",
+    "General Musings": "Personal reflections, thoughts on life, career, identity, and non-technical topics",
+    "Linked List": "Curated link collections and resource roundups"
+  },
+  "usage_patterns": {
+    "most_common": "Web Development",
+    "percentage_technical": 72.4,
+    "percentage_personal": 24.1,
+    "percentage_curated": 3.4
+  }
+}

--- a/.claude/category-taxonomy.json
+++ b/.claude/category-taxonomy.json
@@ -1,34 +1,169 @@
 {
   "metadata": {
-    "totalUniqueCategories": 3,
-    "totalCategoryUsages": 58,
-    "averageCategoriesPerPost": 0.85,
+    "totalCategories": 8,
+    "totalPosts": 59,
     "lastUpdated": "2025-01-25",
-    "note": "Categories use title case format and are stored as arrays in frontmatter"
+    "note": "Migration completed - all posts successfully categorized with new 8-category taxonomy",
+    "migrationRequired": false,
+    "currentState": "Fully migrated to new taxonomy structure"
   },
-  "categories": {
-    "primary": {
-      "Web Development": 42
-    },
-    "secondary": {
-      "General Musings": 14
-    },
-    "specialized": {
-      "Linked List": 2
-    },
-    "uncategorized": {
-      "empty": 1
+  "active_taxonomy": {
+    "categories": {
+      "Technical": {
+        "description": "Pure technical tutorials, how-tos, tool guides, and development practices",
+        "slug": "technical",
+        "post_count": 15,
+        "percentage": 25.4,
+        "examples": [
+          "TypeScript utility types series",
+          "React hooks tutorials", 
+          "Jest configuration guides",
+          "ESLint rule explanations",
+          "TailwindCSS adoption",
+          "Dependency management with Renovate"
+        ],
+        "target_audience": "Developers seeking specific technical knowledge and best practices"
+      },
+      "Learning & Challenges": {
+        "description": "Structured learning experiences, coding challenges, and skill acquisition journeys",
+        "slug": "learning-challenges",
+        "post_count": 14,
+        "percentage": 23.7,
+        "examples": [
+          "100 Days of Code series",
+          "30 Days of Functional Programming",
+          "Functional programming concepts",
+          "Learning journey reflections",
+          "Challenge completion retrospectives"
+        ],
+        "target_audience": "Learning-motivated individuals seeking challenge inspiration and structured learning approaches"
+      },
+      "Personal Growth": {
+        "description": "Self-reflection, identity exploration, life lessons, and habit building",
+        "slug": "personal-growth",
+        "post_count": 10,
+        "percentage": 16.9,
+        "examples": [
+          "Overcoming imposter syndrome",
+          "Goal setting vs themes",
+          "Personal retrospectives",
+          "Community influence on habits",
+          "Life transition reflections",
+          "Creative space exploration"
+        ],
+        "target_audience": "Readers seeking life improvement, self-development, and identity exploration"
+      },
+      "Projects": {
+        "description": "Project showcases, builds, creation stories, and development journeys",
+        "slug": "projects",
+        "post_count": 9,
+        "percentage": 15.3,
+        "examples": [
+          "JavaScript calculator project",
+          "Pomodoro timer creation",
+          "Portfolio rebuilds",
+          "Simon game development",
+          "Blog platform migration",
+          "Wanderful application journey"
+        ],
+        "target_audience": "Developers seeking project inspiration and learning from build processes"
+      },
+      "Career Development": {
+        "description": "Professional growth, workplace skills, leadership, and team dynamics",
+        "slug": "career-development",
+        "post_count": 9,
+        "percentage": 15.3,
+        "examples": [
+          "Mentoring approaches",
+          "Psychological safety in teams",
+          "Sprint goal setting",
+          "Technical presentations",
+          "Team health practices",
+          "Inclusive systems design"
+        ],
+        "target_audience": "Professionals focused on career advancement and workplace effectiveness"
+      },
+      "Resources": {
+        "description": "Curated collections, link roundups, and resource sharing",
+        "slug": "resources",
+        "post_count": 2,
+        "percentage": 3.4,
+        "examples": [
+          "Linked List curated articles",
+          "Tool recommendations",
+          "Resource compilations"
+        ],
+        "target_audience": "Developers and learners seeking curated resources and tools"
+      },
+      "Sports & Recreation": {
+        "description": "Physical activities, cycling, endurance sports, and recreational experiences",
+        "slug": "sports-recreation",
+        "post_count": 0,
+        "percentage": 0,
+        "examples": [
+          "Oregon 3 Capes scenic loop (future)",
+          "Ultra-endurance cycling (future)",
+          "Sports community experiences (future)"
+        ],
+        "target_audience": "Sports enthusiasts and cycling community",
+        "status": "ready for future content"
+      },
+      "Creative Writing": {
+        "description": "Poetry, artistic expression, and creative content",
+        "slug": "creative-writing",
+        "post_count": 0,
+        "percentage": 0,
+        "examples": [
+          "Poetry posts (future)",
+          "Creative reflections (future)",
+          "Artistic expression pieces (future)"
+        ],
+        "target_audience": "Readers seeking artistic inspiration and emotional connection",
+        "status": "ready for future content"
+      }
     }
   },
-  "descriptions": {
-    "Web Development": "Technical posts covering programming, tools, frameworks, and development practices",
-    "General Musings": "Personal reflections, thoughts on life, career, identity, and non-technical topics",
-    "Linked List": "Curated link collections and resource roundups"
+  "migration_summary": {
+    "total_posts_migrated": 59,
+    "migration_date": "2025-01-25",
+    "old_taxonomy": {
+      "Web Development": 42,
+      "General Musings": 14,
+      "Linked List": 2,
+      "Empty": 1
+    },
+    "new_taxonomy": {
+      "Technical": 15,
+      "Learning & Challenges": 14,
+      "Personal Growth": 10,
+      "Projects": 9,
+      "Career Development": 9,
+      "Resources": 2,
+      "Sports & Recreation": 0,
+      "Creative Writing": 0
+    },
+    "distribution_analysis": {
+      "most_common_category": "Technical",
+      "largest_migration_source": "Web Development (split into Technical, Projects, Learning & Challenges)",
+      "content_focus": {
+        "technical_content": 40.7,
+        "personal_content": 32.2,
+        "professional_content": 27.1
+      }
+    }
   },
-  "usage_patterns": {
-    "most_common": "Web Development",
-    "percentage_technical": 72.4,
-    "percentage_personal": 24.1,
-    "percentage_curated": 3.4
+  "implementation_benefits": {
+    "seo": "More specific categories improve search relevance and organic discovery",
+    "navigation": "Readers can quickly find content matching their interests", 
+    "content_planning": "Clearer buckets for planning future content and identifying gaps",
+    "reader_segmentation": "Better serves different audience segments and use cases",
+    "related_content": "Improved content clustering for better recommendations",
+    "scalability": "Ready to accommodate future Sports & Recreation and Creative Writing content"
+  },
+  "content_gaps_identified": {
+    "Sports & Recreation": "Ready for cycling, endurance sports, and recreational content",
+    "Creative Writing": "Ready for poetry, artistic expression, and creative content",
+    "Technical": "Opportunity to expand with more framework-specific tutorials",
+    "Projects": "Space for more complex project showcases and architecture deep-dives"
   }
 }

--- a/.claude/category-taxonomy.json
+++ b/.claude/category-taxonomy.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
     "totalCategories": 8,
-    "totalPosts": 59,
-    "lastUpdated": "2025-01-25",
-    "note": "Migration completed - all posts successfully categorized with new 8-category taxonomy",
+    "totalPosts": 70,
+    "lastUpdated": "2025-01-26",
+    "note": "Migration completed - all posts successfully categorized including 11 previously uncategorized posts",
     "migrationRequired": false,
     "currentState": "Fully migrated to new taxonomy structure"
   },
@@ -41,15 +41,18 @@
       "Personal Growth": {
         "description": "Self-reflection, identity exploration, life lessons, and habit building",
         "slug": "personal-growth",
-        "post_count": 10,
-        "percentage": 16.9,
+        "post_count": 16,
+        "percentage": 22.9,
         "examples": [
           "Overcoming imposter syndrome",
           "Goal setting vs themes",
           "Personal retrospectives",
           "Community influence on habits",
           "Life transition reflections",
-          "Creative space exploration"
+          "Creative space exploration",
+          "Gender identity exploration",
+          "Transition experiences",
+          "Social experiences and belonging"
         ],
         "target_audience": "Readers seeking life improvement, self-development, and identity exploration"
       },
@@ -98,34 +101,34 @@
       "Sports & Recreation": {
         "description": "Physical activities, cycling, endurance sports, and recreational experiences",
         "slug": "sports-recreation",
-        "post_count": 0,
-        "percentage": 0,
+        "post_count": 2,
+        "percentage": 2.9,
         "examples": [
-          "Oregon 3 Capes scenic loop (future)",
-          "Ultra-endurance cycling (future)",
-          "Sports community experiences (future)"
+          "Oregon 3 Capes scenic loop",
+          "Ultra-endurance cycling experiences",
+          "Sports community allyship",
+          "Cycling transition stories"
         ],
-        "target_audience": "Sports enthusiasts and cycling community",
-        "status": "ready for future content"
+        "target_audience": "Sports enthusiasts and cycling community"
       },
       "Creative Writing": {
         "description": "Poetry, artistic expression, and creative content",
         "slug": "creative-writing",
-        "post_count": 0,
-        "percentage": 0,
+        "post_count": 3,
+        "percentage": 4.3,
         "examples": [
-          "Poetry posts (future)",
-          "Creative reflections (future)",
-          "Artistic expression pieces (future)"
+          "Poetry about identity and fluidity",
+          "Creative reflections on survival",
+          "Artistic expression about persistence",
+          "Emotional processing through verse"
         ],
-        "target_audience": "Readers seeking artistic inspiration and emotional connection",
-        "status": "ready for future content"
+        "target_audience": "Readers seeking artistic inspiration and emotional connection"
       }
     }
   },
   "migration_summary": {
-    "total_posts_migrated": 59,
-    "migration_date": "2025-01-25",
+    "total_posts_migrated": 70,
+    "migration_date": "2025-01-26",
     "old_taxonomy": {
       "Web Development": 42,
       "General Musings": 14,
@@ -135,20 +138,20 @@
     "new_taxonomy": {
       "Technical": 15,
       "Learning & Challenges": 14,
-      "Personal Growth": 10,
+      "Personal Growth": 16,
       "Projects": 9,
       "Career Development": 9,
-      "Resources": 2,
-      "Sports & Recreation": 0,
-      "Creative Writing": 0
+      "Creative Writing": 3,
+      "Sports & Recreation": 2,
+      "Resources": 2
     },
     "distribution_analysis": {
-      "most_common_category": "Technical",
+      "most_common_category": "Personal Growth",
       "largest_migration_source": "Web Development (split into Technical, Projects, Learning & Challenges)",
       "content_focus": {
-        "technical_content": 40.7,
-        "personal_content": 32.2,
-        "professional_content": 27.1
+        "technical_content": 41.4,
+        "personal_content": 30.0,
+        "professional_content": 28.6
       }
     }
   },
@@ -161,9 +164,9 @@
     "scalability": "Ready to accommodate future Sports & Recreation and Creative Writing content"
   },
   "content_gaps_identified": {
-    "Sports & Recreation": "Ready for cycling, endurance sports, and recreational content",
-    "Creative Writing": "Ready for poetry, artistic expression, and creative content",
     "Technical": "Opportunity to expand with more framework-specific tutorials",
-    "Projects": "Space for more complex project showcases and architecture deep-dives"
+    "Projects": "Space for more complex project showcases and architecture deep-dives",
+    "Career Development": "Room for more leadership and workplace dynamics content",
+    "Resources": "Potential for more curated collections and tool recommendations"
   }
 }

--- a/.claude/category-taxonomy.json
+++ b/.claude/category-taxonomy.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "totalCategories": 8,
+    "totalCategories": 9,
     "totalPosts": 70,
     "lastUpdated": "2025-01-26",
-    "note": "Migration completed - all posts successfully categorized including 11 previously uncategorized posts",
+    "note": "Migration completed - all posts successfully categorized including new Identity & Intersectionality category",
     "migrationRequired": false,
     "currentState": "Fully migrated to new taxonomy structure"
   },
@@ -39,22 +39,33 @@
         "target_audience": "Learning-motivated individuals seeking challenge inspiration and structured learning approaches"
       },
       "Personal Growth": {
-        "description": "Self-reflection, identity exploration, life lessons, and habit building",
+        "description": "Self-reflection, personal development, life lessons, and habit building",
         "slug": "personal-growth",
-        "post_count": 16,
-        "percentage": 22.9,
+        "post_count": 11,
+        "percentage": 15.7,
         "examples": [
           "Overcoming imposter syndrome",
           "Goal setting vs themes",
           "Personal retrospectives",
           "Community influence on habits",
           "Life transition reflections",
-          "Creative space exploration",
-          "Gender identity exploration",
-          "Transition experiences",
-          "Social experiences and belonging"
+          "Creative space exploration"
         ],
-        "target_audience": "Readers seeking life improvement, self-development, and identity exploration"
+        "target_audience": "Readers seeking life improvement, self-development, and personal growth strategies"
+      },
+      "Identity & Intersectionality": {
+        "description": "Nuanced identity work, social systems analysis, and intersectional perspectives on society",
+        "slug": "identity-intersectionality",
+        "post_count": 4,
+        "percentage": 5.7,
+        "examples": [
+          "Gender identity and social systems",
+          "Intersectional identity analysis",
+          "Social safety and gender dynamics",
+          "Visibility and community solidarity",
+          "Identity taxonomy and perception"
+        ],
+        "target_audience": "Readers interested in identity politics, social justice, and intersectional analysis"
       },
       "Projects": {
         "description": "Project showcases, builds, creation stories, and development journeys",
@@ -114,12 +125,11 @@
       "Creative Writing": {
         "description": "Poetry, artistic expression, and creative content",
         "slug": "creative-writing",
-        "post_count": 3,
-        "percentage": 4.3,
+        "post_count": 2,
+        "percentage": 2.9,
         "examples": [
           "Poetry about identity and fluidity",
           "Creative reflections on survival",
-          "Artistic expression about persistence",
           "Emotional processing through verse"
         ],
         "target_audience": "Readers seeking artistic inspiration and emotional connection"
@@ -138,11 +148,12 @@
     "new_taxonomy": {
       "Technical": 15,
       "Learning & Challenges": 14,
-      "Personal Growth": 16,
+      "Personal Growth": 12,
       "Projects": 9,
       "Career Development": 9,
-      "Creative Writing": 3,
+      "Identity & Intersectionality": 4,
       "Sports & Recreation": 2,
+      "Creative Writing": 2,
       "Resources": 2
     },
     "distribution_analysis": {

--- a/.claude/tag-taxonomy.json
+++ b/.claude/tag-taxonomy.json
@@ -1,0 +1,94 @@
+{
+  "metadata": {
+    "totalUniqueTags": 46,
+    "totalTagUsages": 160,
+    "averageTagsPerPost": 2.35,
+    "lastUpdated": "2025-01-25",
+    "note": "All tags converted to kebab-case format with consistent lowercase"
+  },
+  "tags": {
+    "mostUsed": {
+      "reflections": 12,
+      "projects": 11,
+      "tooling": 10
+    },
+    "frequentlyUsed": {
+      "transgender": 8,
+      "gender": 7,
+      "team-health": 6,
+      "accessibility": 5,
+      "psychological-safety": 5,
+      "react": 5,
+      "functional-programming": 5,
+      "learning": 5
+    },
+    "moderatelyUsed": {
+      "typescript": 4,
+      "personal-growth": 4,
+      "today-i-learned": 3,
+      "graphql": 3,
+      "javascript": 3,
+      "poetry": 3,
+      "retrospectives": 3,
+      "react-hooks": 3,
+      "gatsby": 3,
+      "typescript-generics": 3,
+      "testing": 3,
+      "linting": 3,
+      "community": 3,
+      "creativity": 3,
+      "systems-design": 3
+    },
+    "lessCommon": {
+      "web-development": 2,
+      "neurodiversity": 2,
+      "leadership": 2,
+      "npm": 2,
+      "agile-and-scrum": 2,
+      "code-quality": 2,
+      "themes": 2,
+      "productivity": 2,
+      "ai": 2,
+      "refactoring": 2,
+      "habit-building": 2,
+      "cycling": 2,
+      "inclusion": 2,
+      "history": 2,
+      "mental-health": 1,
+      "ultra-endurance": 1,
+      "ride-report": 1,
+      "css": 1,
+      "organizational-culture": 1,
+      "ethics": 1
+    }
+  },
+  "categories": {
+    "technical": [
+      "react", "typescript", "javascript", "graphql", "gatsby", "react-hooks", 
+      "typescript-generics", "testing", "linting", "web-development", "css", 
+      "tooling", "npm", "code-quality", "ai", "refactoring"
+    ],
+    "personal": [
+      "reflections", "transgender", "gender", "personal-growth", "neurodiversity", 
+      "mental-health", "creativity", "cycling", "ultra-endurance", "ride-report", 
+      "poetry"
+    ],
+    "workplace": [
+      "team-health", "psychological-safety", "leadership", "agile-and-scrum", 
+      "systems-design", "organizational-culture", "inclusion"
+    ],
+    "learning": [
+      "learning", "functional-programming", "today-i-learned", "retrospectives", 
+      "community", "habit-building", "productivity", "themes"
+    ],
+    "accessibility": [
+      "accessibility", "ethics"
+    ],
+    "projects": [
+      "projects"
+    ],
+    "history": [
+      "history"
+    ]
+  }
+}

--- a/.claude/tag-taxonomy.json
+++ b/.claude/tag-taxonomy.json
@@ -4,7 +4,7 @@
     "totalTagUsages": 160,
     "averageTagsPerPost": 2.35,
     "lastUpdated": "2025-01-25",
-    "note": "All tags converted to kebab-case format with consistent lowercase"
+    "note": "All tags use kebab-case format with proper capitalization for technology names and acronyms"
   },
   "tags": {
     "mostUsed": {
@@ -23,16 +23,16 @@
       "learning": 5
     },
     "moderatelyUsed": {
-      "typescript": 4,
+      "TypeScript": 4,
       "personal-growth": 4,
       "today-i-learned": 3,
-      "graphql": 3,
-      "javascript": 3,
+      "GraphQL": 3,
+      "JavaScript": 3,
       "poetry": 3,
       "retrospectives": 3,
       "react-hooks": 3,
       "gatsby": 3,
-      "typescript-generics": 3,
+      "TypeScript-generics": 3,
       "testing": 3,
       "linting": 3,
       "community": 3,
@@ -48,7 +48,7 @@
       "code-quality": 2,
       "themes": 2,
       "productivity": 2,
-      "ai": 2,
+      "AI": 2,
       "refactoring": 2,
       "habit-building": 2,
       "cycling": 2,
@@ -57,16 +57,16 @@
       "mental-health": 1,
       "ultra-endurance": 1,
       "ride-report": 1,
-      "css": 1,
+      "CSS": 1,
       "organizational-culture": 1,
       "ethics": 1
     }
   },
   "categories": {
     "technical": [
-      "react", "typescript", "javascript", "graphql", "gatsby", "react-hooks", 
-      "typescript-generics", "testing", "linting", "web-development", "css", 
-      "tooling", "npm", "code-quality", "ai", "refactoring"
+      "react", "TypeScript", "JavaScript", "GraphQL", "gatsby", "react-hooks", 
+      "TypeScript-generics", "testing", "linting", "web-development", "CSS", 
+      "tooling", "npm", "code-quality", "AI", "refactoring"
     ],
     "personal": [
       "reflections", "transgender", "gender", "personal-growth", "neurodiversity", 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,61 +63,8 @@ This is a Hugo static site generator blog using the PaperMod theme with several 
 
 ## Content Taxonomy
 
-### Tags
-Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tags to posts. Contains 46 unique tags with usage counts and categorization by topic (technical, personal, workplace, learning, accessibility, projects). Use this to maintain consistency and discover related tags.
+For detailed guidance on applying categories and tags to blog posts, reference @.claude/blog-taxonomy-guide.md.
 
-#### Tag Capitalization Rules
-- Use kebab-case format for multi-word tags
-- Technology names and acronyms should use proper capitalization:
-  - `JavaScript` (not `javascript`)
-  - `TypeScript` (not `typescript`) 
-  - `GraphQL` (not `graphql`)
-  - `CSS` (not `css`)
-  - `AI` (not `ai`)
-- Compound technical tags maintain proper capitalization: `TypeScript-generics`
-- General concept tags remain lowercase: `tooling`, `accessibility`, `learning`
-
-### Categories
-Reference @.claude/category-taxonomy.json for the category structure when categorizing posts. The taxonomy has been updated to a 9-category system for better content discoverability:
-
-#### Recommended Category Structure
-- **Technical**: Pure technical tutorials, how-tos, tool guides
-- **Learning & Challenges**: Structured learning experiences, coding challenges
-- **Personal Growth**: Self-reflection, personal development, life lessons, habit building
-- **Projects**: Project showcases, builds, creation stories  
-- **Career Development**: Professional growth, workplace skills, leadership
-- **Identity & Intersectionality**: Nuanced identity work, social systems analysis, intersectional perspectives
-- **Sports & Recreation**: Physical activities, cycling, endurance sports
-- **Creative Writing**: Poetry, artistic expression
-- **Resources**: Curated collections, link roundups
-
-Categories use title case format and are stored as arrays in frontmatter. Each post should have exactly one category for optimal information architecture.
-
-#### Category Implementation with Special Characters
-Categories containing special characters (like "&") use kebab-case directory names with a display title set in the category's `_index.md`:
-
-**Directory Structure:**
-```
-content/categories/
-├── identity-and-intersectionality/
-│   └── _index.md
-├── learning-and-challenges/
-│   └── _index.md
-└── sports-and-recreation/
-    └── _index.md
-```
-
-**Category Index File Format:**
-```yaml
----
-title: 'Identity & Intersectionality'
-description: 'Nuanced identity work, social systems analysis, and intersectional perspectives on society.'
----
-```
-
-**In Post Frontmatter:**
-```yaml
-categories: ['identity-and-intersectionality']
-```
-
-This approach ensures URL-safe directory names while maintaining proper display formatting with special characters.
+### Quick Reference
+- **Categories**: Reference @.claude/category-taxonomy.json (9 categories total)
+- **Tags**: Reference @.claude/tag-taxonomy.json (46 unique tags)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,16 @@ Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tag
 - General concept tags remain lowercase: `tooling`, `accessibility`, `learning`
 
 ### Categories
-Reference @.claude/category-taxonomy.json for the category structure when categorizing posts. Contains 3 main categories:
-- **Web Development** (72% of posts): Technical content covering programming, tools, frameworks, and development practices
-- **General Musings** (24% of posts): Personal reflections, thoughts on life, career, identity, and non-technical topics  
-- **Linked List** (3% of posts): Curated link collections and resource roundups
+Reference @.claude/category-taxonomy.json for the category structure when categorizing posts. The taxonomy has been updated to an 8-category system for better content discoverability:
 
-Categories use title case format and are stored as arrays in frontmatter.
+#### Recommended Category Structure
+- **Technical**: Pure technical tutorials, how-tos, tool guides
+- **Projects**: Project showcases, builds, creation stories  
+- **Career Development**: Professional growth, workplace skills, leadership
+- **Personal Growth**: Self-reflection, identity exploration, life lessons
+- **Learning & Challenges**: Structured learning experiences, coding challenges
+- **Sports & Recreation**: Physical activities, cycling, endurance sports
+- **Creative Writing**: Poetry, artistic expression
+- **Resources**: Curated collections, link roundups
+
+Categories use title case format and are stored as arrays in frontmatter. Each post should have exactly one category for optimal information architecture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Content Creation
+```bash
+# Create new post with images folder (preferred for posts with images)
+make new-post-images name="post-name"
+
+# Create text-only post
+make new-post-text name="post-name"
+
+# Manual content creation
+hugo new posts/post-name/index.md
+```
+
+### Development Server
+```bash
+# Start development server with drafts
+hugo server -D
+
+# Build for production
+hugo
+```
+
+## Architecture Overview
+
+This is a Hugo static site generator blog using the PaperMod theme with several customizations:
+
+### Hugo Modules Structure
+- **Theme**: `github.com/adityatelange/hugo-PaperMod` (main theme)
+- **Analytics**: `github.com/hugomods/umami-analytics` (privacy-focused)
+- **Gallery**: `github.com/mfg92/hugo-shortcode-gallery` (image galleries)
+
+### Content Organization
+- **Posts location**: `/content/posts/`
+- **Post formats**: 
+  - Bundle format: `post-name/index.md` + `images/` folder (recommended)
+  - Single file: `post-name.md`
+- **Taxonomies**: Categories, Tags, Series (custom taxonomy for grouping related posts)
+- **Permalinks**: Posts use `/blog/:slug` pattern
+
+### Theme Customizations
+- **Custom CSS**: `/assets/css/extended/custom.css` contains site-specific styling
+- **Layouts**: Custom layouts in `/layouts/` for series support and newsletter integration
+- **Newsletter**: ConvertKit integration with dark/light theme awareness
+- **Analytics**: Umami privacy analytics (production only)
+
+### Key Configuration
+- **Base URL**: skylerlemay.com
+- **Default theme**: Dark mode
+- **Markdown**: Unsafe HTML rendering enabled for flexibility
+- **Edit links**: GitHub edit functionality enabled for community contributions
+
+### Development Notes
+- Posts support frontmatter series assignment for cross-linking
+- Custom accent color: `#5928a4` (purple theme)
+- Newsletter signup forms adapt to current theme (dark/light)
+- Production builds include minification and analytics
+- Static redirects handled via `/static/_redirects`
+
+## Content Taxonomy
+
+Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tags to posts. Contains 46 unique tags with usage counts and categorization by topic (technical, personal, workplace, learning, accessibility, projects). Use this to maintain consistency and discover related tags.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,10 @@ This is a Hugo static site generator blog using the PaperMod theme with several 
 
 ## Content Taxonomy
 
+### Tags
 Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tags to posts. Contains 46 unique tags with usage counts and categorization by topic (technical, personal, workplace, learning, accessibility, projects). Use this to maintain consistency and discover related tags.
 
-### Tag Capitalization Rules
+#### Tag Capitalization Rules
 - Use kebab-case format for multi-word tags
 - Technology names and acronyms should use proper capitalization:
   - `JavaScript` (not `javascript`)
@@ -75,3 +76,11 @@ Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tag
   - `AI` (not `ai`)
 - Compound technical tags maintain proper capitalization: `TypeScript-generics`
 - General concept tags remain lowercase: `tooling`, `accessibility`, `learning`
+
+### Categories
+Reference @.claude/category-taxonomy.json for the category structure when categorizing posts. Contains 3 main categories:
+- **Web Development** (72% of posts): Technical content covering programming, tools, frameworks, and development practices
+- **General Musings** (24% of posts): Personal reflections, thoughts on life, career, identity, and non-technical topics  
+- **Linked List** (3% of posts): Curated link collections and resource roundups
+
+Categories use title case format and are stored as arrays in frontmatter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,14 @@ This is a Hugo static site generator blog using the PaperMod theme with several 
 ## Content Taxonomy
 
 Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tags to posts. Contains 46 unique tags with usage counts and categorization by topic (technical, personal, workplace, learning, accessibility, projects). Use this to maintain consistency and discover related tags.
+
+### Tag Capitalization Rules
+- Use kebab-case format for multi-word tags
+- Technology names and acronyms should use proper capitalization:
+  - `JavaScript` (not `javascript`)
+  - `TypeScript` (not `typescript`) 
+  - `GraphQL` (not `graphql`)
+  - `CSS` (not `css`)
+  - `AI` (not `ai`)
+- Compound technical tags maintain proper capitalization: `TypeScript-generics`
+- General concept tags remain lowercase: `tooling`, `accessibility`, `learning`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,3 +92,32 @@ Reference @.claude/category-taxonomy.json for the category structure when catego
 - **Resources**: Curated collections, link roundups
 
 Categories use title case format and are stored as arrays in frontmatter. Each post should have exactly one category for optimal information architecture.
+
+#### Category Implementation with Special Characters
+Categories containing special characters (like "&") use kebab-case directory names with a display title set in the category's `_index.md`:
+
+**Directory Structure:**
+```
+content/categories/
+├── identity-and-intersectionality/
+│   └── _index.md
+├── learning-and-challenges/
+│   └── _index.md
+└── sports-and-recreation/
+    └── _index.md
+```
+
+**Category Index File Format:**
+```yaml
+---
+title: 'Identity & Intersectionality'
+description: 'Nuanced identity work, social systems analysis, and intersectional perspectives on society.'
+---
+```
+
+**In Post Frontmatter:**
+```yaml
+categories: ['identity-and-intersectionality']
+```
+
+This approach ensures URL-safe directory names while maintaining proper display formatting with special characters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,14 +78,15 @@ Reference @.claude/tag-taxonomy.json for complete tag taxonomy when applying tag
 - General concept tags remain lowercase: `tooling`, `accessibility`, `learning`
 
 ### Categories
-Reference @.claude/category-taxonomy.json for the category structure when categorizing posts. The taxonomy has been updated to an 8-category system for better content discoverability:
+Reference @.claude/category-taxonomy.json for the category structure when categorizing posts. The taxonomy has been updated to a 9-category system for better content discoverability:
 
 #### Recommended Category Structure
 - **Technical**: Pure technical tutorials, how-tos, tool guides
+- **Learning & Challenges**: Structured learning experiences, coding challenges
+- **Personal Growth**: Self-reflection, personal development, life lessons, habit building
 - **Projects**: Project showcases, builds, creation stories  
 - **Career Development**: Professional growth, workplace skills, leadership
-- **Personal Growth**: Self-reflection, identity exploration, life lessons
-- **Learning & Challenges**: Structured learning experiences, coding challenges
+- **Identity & Intersectionality**: Nuanced identity work, social systems analysis, intersectional perspectives
 - **Sports & Recreation**: Physical activities, cycling, endurance sports
 - **Creative Writing**: Poetry, artistic expression
 - **Resources**: Curated collections, link roundups

--- a/content/categories/career-development/_index.md
+++ b/content/categories/career-development/_index.md
@@ -1,0 +1,4 @@
+---
+title: 'Career Development'
+description: 'Professional growth, workplace skills, leadership, and team dynamics.'
+---

--- a/content/categories/identity-and-intersectionality/_index.md
+++ b/content/categories/identity-and-intersectionality/_index.md
@@ -1,0 +1,4 @@
+---
+title: 'Identity & Intersectionality'
+description: 'Nuanced identity work, social systems analysis, and intersectional perspectives on society.'
+---

--- a/content/categories/learning-and-challenges/_index.md
+++ b/content/categories/learning-and-challenges/_index.md
@@ -1,0 +1,4 @@
+---
+title: 'Learning & Challenges'
+description: "Structured learning experiences, coding challenges, and skill acquisition journeys."
+---

--- a/content/categories/personal-growth/_index.md
+++ b/content/categories/personal-growth/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Personal Growth"
+description: "Self-reflection, personal development, life lessons, and habit building."
+---

--- a/content/categories/projects/_index.md
+++ b/content/categories/projects/_index.md
@@ -1,0 +1,4 @@
+---
+title: Projects
+description: 'Project showcases, builds, creation stories, and development journeys.'
+---

--- a/content/categories/sports-and-recreation/_index.md
+++ b/content/categories/sports-and-recreation/_index.md
@@ -1,0 +1,4 @@
+---
+title: 'Sports & Recreation'
+description: 'Physical activities, cycling, endurance sports, and recreational experiences.'
+---

--- a/content/categories/technical/_index.md
+++ b/content/categories/technical/_index.md
@@ -1,0 +1,4 @@
+---
+title: Technical
+description: "Pure technical tutorials, how-tos, tool guides, and development practices."
+---

--- a/content/posts/100daysofcode-round-2-week-2-and-engaging-with-test-driven-development/index.md
+++ b/content/posts/100daysofcode-round-2-week-2-and-engaging-with-test-driven-development/index.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Round 2, Week 2 and Engaging with Test Driven Development
 slug: '100daysofcode-round-2-week-2-and-engaging-with-test-driven-development'
 draft: false
 publishDate: '2017-12-16'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-round-2-week-2-and-engaging-with-test-driven-development/index.md
+++ b/content/posts/100daysofcode-round-2-week-2-and-engaging-with-test-driven-development/index.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Round 2, Week 2 and Engaging with Test Driven Development
 slug: '100daysofcode-round-2-week-2-and-engaging-with-test-driven-development'
 draft: false
 publishDate: '2017-12-16'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-round-2-week-5.md
+++ b/content/posts/100daysofcode-round-2-week-5.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Round 2, Week 5'
 slug: '100daysofcode-round-2-week-5'
 draft: false
 publishDate: '2018-01-15'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-round-2-week-5.md
+++ b/content/posts/100daysofcode-round-2-week-5.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Round 2, Week 5'
 slug: '100daysofcode-round-2-week-5'
 draft: false
 publishDate: '2018-01-15'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-round-2-weeks-3-and-4/index.md
+++ b/content/posts/100daysofcode-round-2-weeks-3-and-4/index.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Round 2, Weeks 3 and 4'
 slug: '100daysofcode-round-2-weeks-3-and-4'
 draft: false
 publishDate: '2017-12-30'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-round-2-weeks-3-and-4/index.md
+++ b/content/posts/100daysofcode-round-2-weeks-3-and-4/index.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Round 2, Weeks 3 and 4'
 slug: '100daysofcode-round-2-weeks-3-and-4'
 draft: false
 publishDate: '2017-12-30'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-week-1.md
+++ b/content/posts/100daysofcode-week-1.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Week 1'
 slug: '100daysofcode-week-1'
 draft: false
 publishDate: '2017-08-17'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 series: ['100 Days of Code']
 ---
 > The concept and desire for instant or near-instant gratification has so permeated society that struggling with a problem can become more than arduous.

--- a/content/posts/100daysofcode-week-1.md
+++ b/content/posts/100daysofcode-week-1.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Week 1'
 slug: '100daysofcode-week-1'
 draft: false
 publishDate: '2017-08-17'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 series: ['100 Days of Code']
 ---
 > The concept and desire for instant or near-instant gratification has so permeated society that struggling with a problem can become more than arduous.

--- a/content/posts/100daysofcode-week-2-3.md
+++ b/content/posts/100daysofcode-week-2-3.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Week 2 & 3'
 slug: '100daysofcode-week-2-3'
 draft: false
 publishDate: '2017-08-29'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ['Projects']
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-week-2-3.md
+++ b/content/posts/100daysofcode-week-2-3.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Week 2 & 3'
 slug: '100daysofcode-week-2-3'
 draft: false
 publishDate: '2017-08-29'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ['Projects']
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-week-4-5.md
+++ b/content/posts/100daysofcode-week-4-5.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Week 4 & 5'
 slug: '100daysofcode-week-4-5'
 draft: false
 publishDate: '2017-09-16'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/100daysofcode-week-4-5.md
+++ b/content/posts/100daysofcode-week-4-5.md
@@ -3,7 +3,7 @@ title: '#100DaysOfCode Week 4 & 5'
 slug: '100daysofcode-week-4-5'
 draft: false
 publishDate: '2017-09-16'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/2017-a-year-of-rediscovering-myself-and-my-passion/index.md
+++ b/content/posts/2017-a-year-of-rediscovering-myself-and-my-passion/index.md
@@ -3,7 +3,7 @@ title: '2017: A Year of Rediscovering Myself and My Passion'
 slug: '2017-a-year-of-rediscovering-myself-and-my-passion'
 draft: false
 publishDate: '2018-01-09'
-categories: ['Web Development']
+categories: ['Personal Growth']
 tags: []
 ---
 ![2017: A Year of Rediscovering Myself and My Passion](images/2017-01-github-commits.jpg#center)

--- a/content/posts/30-days-of-functional-programming/index.md
+++ b/content/posts/30-days-of-functional-programming/index.md
@@ -4,7 +4,7 @@ slug: '30-days-of-functional-programming'
 draft: false
 publishDate: '2019-08-01'
 categories: ['Web Development']
-tags: ["Reflections","Functional Programming","Learning","Habit Building","Personal Growth"]
+tags: ["reflections","functional-programming","learning","habit-building","personal-growth"]
 series: ['30 Days of Functional Programming']
 ---
 ![30 Days of Functional Programming](images/library-hanging-bulbs.jpg#center)

--- a/content/posts/30-days-of-functional-programming/index.md
+++ b/content/posts/30-days-of-functional-programming/index.md
@@ -3,7 +3,7 @@ title: '30 Days of Functional Programming'
 slug: '30-days-of-functional-programming'
 draft: false
 publishDate: '2019-08-01'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ["reflections","functional-programming","learning","habit-building","personal-growth"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/30-days-of-functional-programming/index.md
+++ b/content/posts/30-days-of-functional-programming/index.md
@@ -3,7 +3,7 @@ title: '30 Days of Functional Programming'
 slug: '30-days-of-functional-programming'
 draft: false
 publishDate: '2019-08-01'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ["reflections","functional-programming","learning","habit-building","personal-growth"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/4-perspectives-to-maintain-and-make-mentoring-approachable.md
+++ b/content/posts/4-perspectives-to-maintain-and-make-mentoring-approachable.md
@@ -4,7 +4,7 @@ slug: '4-perspectives-to-maintain-and-make-mentoring-approachable'
 draft: false
 publishDate: '2018-12-03'
 categories: ['General Musings']
-tags: ["Reflections","Leadership","Team Health"]
+tags: ["reflections","leadership","team-health"]
 ---
 > When we embrace the concept of skillset diversity amongst disciplines, it provides opportunity for people to share knowledge and teach others irrespective of *years of experience*.
 

--- a/content/posts/4-perspectives-to-maintain-and-make-mentoring-approachable.md
+++ b/content/posts/4-perspectives-to-maintain-and-make-mentoring-approachable.md
@@ -3,7 +3,7 @@ title: '4 Perspectives to Maintain and make Mentoring Approachable'
 slug: '4-perspectives-to-maintain-and-make-mentoring-approachable'
 draft: false
 publishDate: '2018-12-03'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["reflections","leadership","team-health"]
 ---
 > When we embrace the concept of skillset diversity amongst disciplines, it provides opportunity for people to share knowledge and teach others irrespective of *years of experience*.

--- a/content/posts/8-new-eslint-rules-jest/index.md
+++ b/content/posts/8-new-eslint-rules-jest/index.md
@@ -3,7 +3,7 @@ title: '8 New ESLint Rules - Jest'
 slug: '8-new-eslint-rules-jest'
 draft: false
 publishDate: '2019-09-09'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["linting","tooling","testing"]
 ---
 ![8 New ESLint Rules - Jest](images/markus-spiske-stacked-stones.jpg#center)

--- a/content/posts/8-new-eslint-rules-jest/index.md
+++ b/content/posts/8-new-eslint-rules-jest/index.md
@@ -4,7 +4,7 @@ slug: '8-new-eslint-rules-jest'
 draft: false
 publishDate: '2019-09-09'
 categories: ['Web Development']
-tags: ["Linting","Tooling","Testing"]
+tags: ["linting","tooling","testing"]
 ---
 ![8 New ESLint Rules - Jest](images/markus-spiske-stacked-stones.jpg#center)
 

--- a/content/posts/a-juxtaposition-of-social-experiences/index.md
+++ b/content/posts/a-juxtaposition-of-social-experiences/index.md
@@ -4,6 +4,7 @@ slug: 'a-juxtaposition-of-social-experiences'
 description: "How it feels to finally be at home in my body"
 draft: false
 publishDate: '2025-05-07'
+categories: ["Personal Growth"]
 tags: ["neurodiversity", "transgender", "gender"]
 ---
 {{< figure

--- a/content/posts/a-juxtaposition-of-social-experiences/index.md
+++ b/content/posts/a-juxtaposition-of-social-experiences/index.md
@@ -4,7 +4,7 @@ slug: 'a-juxtaposition-of-social-experiences'
 description: "How it feels to finally be at home in my body"
 draft: false
 publishDate: '2025-05-07'
-tags: ["Neurodiversity", "Transgender", "Gender"]
+tags: ["neurodiversity", "transgender", "gender"]
 ---
 {{< figure
   src="images/baby-fern.jpeg"

--- a/content/posts/a-juxtaposition-of-social-experiences/index.md
+++ b/content/posts/a-juxtaposition-of-social-experiences/index.md
@@ -5,7 +5,7 @@ description: "How it feels to finally be at home in my body"
 draft: false
 publishDate: '2025-05-07'
 categories: ["Personal Growth"]
-tags: ["neurodiversity", "transgender", "gender"]
+tags: ['neurodiversity', 'transgender', 'gender', 'reflections']
 ---
 {{< figure
   src="images/baby-fern.jpeg"

--- a/content/posts/a-week-in-review-100daysofcode-round-2-week-1.md
+++ b/content/posts/a-week-in-review-100daysofcode-round-2-week-1.md
@@ -3,7 +3,7 @@ title: 'A Week in Review: #100DaysOfCode Round 2, Week 1'
 slug: 'a-week-in-review-100daysofcode-round-2-week-1'
 draft: false
 publishDate: '2017-12-07'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/a-week-in-review-100daysofcode-round-2-week-1.md
+++ b/content/posts/a-week-in-review-100daysofcode-round-2-week-1.md
@@ -3,7 +3,7 @@ title: 'A Week in Review: #100DaysOfCode Round 2, Week 1'
 slug: 'a-week-in-review-100daysofcode-round-2-week-1'
 draft: false
 publishDate: '2017-12-07'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: []
 series: ['100 Days of Code']
 ---

--- a/content/posts/an-intro-to-functional-programming-30daysoffp-week-1/index.md
+++ b/content/posts/an-intro-to-functional-programming-30daysoffp-week-1/index.md
@@ -3,7 +3,7 @@ title: 'An intro to Functional Programming - 30DaysofFP Week 1'
 slug: 'an-intro-to-functional-programming-30daysoffp-week-1'
 draft: false
 publishDate: '2019-08-12'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/an-intro-to-functional-programming-30daysoffp-week-1/index.md
+++ b/content/posts/an-intro-to-functional-programming-30daysoffp-week-1/index.md
@@ -3,7 +3,7 @@ title: 'An intro to Functional Programming - 30DaysofFP Week 1'
 slug: 'an-intro-to-functional-programming-30daysoffp-week-1'
 draft: false
 publishDate: '2019-08-12'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/an-intro-to-functional-programming-30daysoffp-week-1/index.md
+++ b/content/posts/an-intro-to-functional-programming-30daysoffp-week-1/index.md
@@ -4,7 +4,7 @@ slug: 'an-intro-to-functional-programming-30daysoffp-week-1'
 draft: false
 publishDate: '2019-08-12'
 categories: ['Web Development']
-tags: ["Functional Programming"]
+tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---
 ![An intro to Functional Programming - 30DaysofFP Week 1](images/rope-meshwork.jpg#center)

--- a/content/posts/better-dependency-management-using-renovate/index.md
+++ b/content/posts/better-dependency-management-using-renovate/index.md
@@ -4,7 +4,7 @@ slug: 'better-dependency-management-using-renovate'
 draft: false
 publishDate: '2019-11-18'
 categories: ['Web Development']
-tags: ["Tooling","NPM","Productivity","Code Quality","JavaScript"]
+tags: ["tooling","npm","productivity","code-quality","javascript"]
 ---
 ![Better Dependency Management Using Renovate](images/shipping-crates-stacked.jpg#center)
 

--- a/content/posts/better-dependency-management-using-renovate/index.md
+++ b/content/posts/better-dependency-management-using-renovate/index.md
@@ -4,7 +4,7 @@ slug: 'better-dependency-management-using-renovate'
 draft: false
 publishDate: '2019-11-18'
 categories: ['Web Development']
-tags: ["tooling","npm","productivity","code-quality","javascript"]
+tags: ["tooling","npm","productivity","code-quality","JavaScript"]
 ---
 ![Better Dependency Management Using Renovate](images/shipping-crates-stacked.jpg#center)
 

--- a/content/posts/better-dependency-management-using-renovate/index.md
+++ b/content/posts/better-dependency-management-using-renovate/index.md
@@ -3,7 +3,7 @@ title: 'Better Dependency Management Using Renovate'
 slug: 'better-dependency-management-using-renovate'
 draft: false
 publishDate: '2019-11-18'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["tooling","npm","productivity","code-quality","JavaScript"]
 ---
 ![Better Dependency Management Using Renovate](images/shipping-crates-stacked.jpg#center)

--- a/content/posts/building-tic-tac-toe-mental-obstacles-and-the-benefits-of-react/index.md
+++ b/content/posts/building-tic-tac-toe-mental-obstacles-and-the-benefits-of-react/index.md
@@ -3,7 +3,7 @@ title: 'Building Tic Tac Toe, Mental Obstacles, and the Benefits of React'
 slug: 'building-tic-tac-toe-mental-obstacles-and-the-benefits-of-react'
 draft: false
 publishDate: '2017-08-22'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ['Projects']
 ---
 ![Tic Tac Toe Game Interface](images/2017-08-tic-tac-toe-v1.jpg#center)

--- a/content/posts/chaos-and-beauty-through-dissolution/index.md
+++ b/content/posts/chaos-and-beauty-through-dissolution/index.md
@@ -4,7 +4,7 @@ slug: 'chaos-and-beauty-through-dissolution'
 description: "How I've never been more wrong about a statement than I was 3 years ago and am forever grateful"
 draft: false
 publishDate: '2025-03-20'
-tags: ["Gender", "Transgender"]
+tags: ["gender", "transgender"]
 ---
 {{< figure
   src="images/tesseract.jpeg"

--- a/content/posts/chaos-and-beauty-through-dissolution/index.md
+++ b/content/posts/chaos-and-beauty-through-dissolution/index.md
@@ -5,7 +5,7 @@ description: "How I've never been more wrong about a statement than I was 3 year
 draft: false
 publishDate: '2025-03-20'
 categories: ["Personal Growth"]
-tags: ["gender", "transgender"]
+tags: ['gender', 'transgender', 'reflections', 'neurodiversity']
 ---
 {{< figure
   src="images/tesseract.jpeg"

--- a/content/posts/chaos-and-beauty-through-dissolution/index.md
+++ b/content/posts/chaos-and-beauty-through-dissolution/index.md
@@ -4,6 +4,7 @@ slug: 'chaos-and-beauty-through-dissolution'
 description: "How I've never been more wrong about a statement than I was 3 years ago and am forever grateful"
 draft: false
 publishDate: '2025-03-20'
+categories: ["Personal Growth"]
 tags: ["gender", "transgender"]
 ---
 {{< figure

--- a/content/posts/community-influence-when-building-a-habit/index.md
+++ b/content/posts/community-influence-when-building-a-habit/index.md
@@ -4,7 +4,7 @@ slug: 'community-influence-when-building-a-habit'
 draft: false
 publishDate: '2020-12-23'
 categories: ['General Musings']
-tags: ["Reflections","Community"]
+tags: ["reflections","community"]
 ---
 ![Community Influence when Building a Habit](images/together-we-create.jpg#center)
 

--- a/content/posts/community-influence-when-building-a-habit/index.md
+++ b/content/posts/community-influence-when-building-a-habit/index.md
@@ -3,7 +3,7 @@ title: 'Community Influence when Building a Habit'
 slug: 'community-influence-when-building-a-habit'
 draft: false
 publishDate: '2020-12-23'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ["reflections","community"]
 ---
 ![Community Influence when Building a Habit](images/together-we-create.jpg#center)

--- a/content/posts/completing-my-pomodoro-timer-project/index.md
+++ b/content/posts/completing-my-pomodoro-timer-project/index.md
@@ -4,7 +4,7 @@ slug: 'completing-my-pomodoro-timer-project'
 draft: false
 publishDate: '2017-08-13'
 categories: ['Projects']
-tags: ['Projects']
+tags: ['react', 'JavaScript', 'learning']
 ---
 ![Pomodoro Timer](images/2017-08-pomodoro-timer-v1.jpg)
 

--- a/content/posts/completing-my-pomodoro-timer-project/index.md
+++ b/content/posts/completing-my-pomodoro-timer-project/index.md
@@ -3,7 +3,7 @@ title: 'Completing my Pomodoro Timer Project'
 slug: 'completing-my-pomodoro-timer-project'
 draft: false
 publishDate: '2017-08-13'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ['Projects']
 ---
 ![Pomodoro Timer](images/2017-08-pomodoro-timer-v1.jpg)

--- a/content/posts/completing-simon-game-and-my-front-end-certification/index.md
+++ b/content/posts/completing-simon-game-and-my-front-end-certification/index.md
@@ -3,7 +3,7 @@ title: 'Completing Simon Game and my Front End Certification'
 slug: 'completing-simon-game-and-my-front-end-certification'
 draft: false
 publishDate: '2017-08-27'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ['Projects', 'React', 'Learning', 'Web Development']
 ---
 ![Simon Game](images/2017-08-simon-game.jpg#center)

--- a/content/posts/completing-simon-game-and-my-front-end-certification/index.md
+++ b/content/posts/completing-simon-game-and-my-front-end-certification/index.md
@@ -4,7 +4,7 @@ slug: 'completing-simon-game-and-my-front-end-certification'
 draft: false
 publishDate: '2017-08-27'
 categories: ['Projects']
-tags: ['Projects', 'React', 'Learning', 'Web Development']
+tags: ['react', 'JavaScript', 'learning']
 ---
 ![Simon Game](images/2017-08-simon-game.jpg#center)
 

--- a/content/posts/conceptualizing-and-creating-a-new-portfolio/index.md
+++ b/content/posts/conceptualizing-and-creating-a-new-portfolio/index.md
@@ -3,7 +3,7 @@ title: 'Conceptualizing and Creating a New Portfolio'
 slug: 'conceptualizing-and-creating-a-new-portfolio'
 draft: false
 publishDate: '2018-02-13'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ["projects","react","gatsby","GraphQL"]
 ---
 ![Conceptualizing and Creating a New Portfolio](images/2018-02-website-hero.jpg#center)

--- a/content/posts/conceptualizing-and-creating-a-new-portfolio/index.md
+++ b/content/posts/conceptualizing-and-creating-a-new-portfolio/index.md
@@ -4,7 +4,7 @@ slug: 'conceptualizing-and-creating-a-new-portfolio'
 draft: false
 publishDate: '2018-02-13'
 categories: ['Web Development']
-tags: ["projects","react","gatsby","graphql"]
+tags: ["projects","react","gatsby","GraphQL"]
 ---
 ![Conceptualizing and Creating a New Portfolio](images/2018-02-website-hero.jpg#center)
 

--- a/content/posts/conceptualizing-and-creating-a-new-portfolio/index.md
+++ b/content/posts/conceptualizing-and-creating-a-new-portfolio/index.md
@@ -4,7 +4,7 @@ slug: 'conceptualizing-and-creating-a-new-portfolio'
 draft: false
 publishDate: '2018-02-13'
 categories: ['Web Development']
-tags: ["Projects","React","Gatsby","GraphQL"]
+tags: ["projects","react","gatsby","graphql"]
 ---
 ![Conceptualizing and Creating a New Portfolio](images/2018-02-website-hero.jpg#center)
 

--- a/content/posts/deconstructing-identity-and-the-lenses-of-perception/index.md
+++ b/content/posts/deconstructing-identity-and-the-lenses-of-perception/index.md
@@ -3,7 +3,7 @@ title: 'Deconstructing Identity and the Lenses of Perception'
 slug: 'deconstructing-identity-and-the-lenses-of-perception'
 draft: false
 publishDate: '2024-06-04'
-categories: ["Personal Growth"]
+categories: ["Identity & Intersectionality"]
 tags: ['gender', 'transgender']
 ---
 Identity is primarily described as an internal sense of being. My internal existence is held tightly—it was a challenging, emotional, and difficult thing to admit, explore, and ultimately claim as my own. However, identity doesn't exist in a vacuum. We are surrounded by individuals, communities, and systems which create their own taxonomies of classification. How do I acclimate to taxonomies which don't align with my nuanced reality?

--- a/content/posts/deconstructing-identity-and-the-lenses-of-perception/index.md
+++ b/content/posts/deconstructing-identity-and-the-lenses-of-perception/index.md
@@ -3,7 +3,8 @@ title: 'Deconstructing Identity and the Lenses of Perception'
 slug: 'deconstructing-identity-and-the-lenses-of-perception'
 draft: false
 publishDate: '2024-06-04'
-tags: ['Gender', 'Transgender']
+categories: ["Personal Growth"]
+tags: ['gender', 'transgender']
 ---
 Identity is primarily described as an internal sense of being. My internal existence is held tightly—it was a challenging, emotional, and difficult thing to admit, explore, and ultimately claim as my own. However, identity doesn't exist in a vacuum. We are surrounded by individuals, communities, and systems which create their own taxonomies of classification. How do I acclimate to taxonomies which don't align with my nuanced reality?
 

--- a/content/posts/deconstructing-identity-and-the-lenses-of-perception/index.md
+++ b/content/posts/deconstructing-identity-and-the-lenses-of-perception/index.md
@@ -3,7 +3,7 @@ title: 'Deconstructing Identity and the Lenses of Perception'
 slug: 'deconstructing-identity-and-the-lenses-of-perception'
 draft: false
 publishDate: '2024-06-04'
-categories: ["Identity & Intersectionality"]
+categories: ["identity-and-intersectionality"]
 tags: ['gender', 'transgender']
 ---
 Identity is primarily described as an internal sense of being. My internal existence is held tightly—it was a challenging, emotional, and difficult thing to admit, explore, and ultimately claim as my own. However, identity doesn't exist in a vacuum. We are surrounded by individuals, communities, and systems which create their own taxonomies of classification. How do I acclimate to taxonomies which don't align with my nuanced reality?

--- a/content/posts/embarking-on-the-year-of-creation/index.md
+++ b/content/posts/embarking-on-the-year-of-creation/index.md
@@ -3,7 +3,7 @@ title: 'Embarking on the Year of Creation'
 slug: 'embarking-on-the-year-of-creation'
 draft: false
 publishDate: '2020-12-29'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ["reflections","themes","creativity","productivity","personal-growth"]
 ---
 ![Embarking on the Year of Creation](images/dandelion-seed-distribution.jpg#center)

--- a/content/posts/embarking-on-the-year-of-creation/index.md
+++ b/content/posts/embarking-on-the-year-of-creation/index.md
@@ -4,7 +4,7 @@ slug: 'embarking-on-the-year-of-creation'
 draft: false
 publishDate: '2020-12-29'
 categories: ['General Musings']
-tags: ["Reflections","Themes","Creativity","Productivity","Personal Growth"]
+tags: ["reflections","themes","creativity","productivity","personal-growth"]
 ---
 ![Embarking on the Year of Creation](images/dandelion-seed-distribution.jpg#center)
 

--- a/content/posts/empower-teams-with-sprint-goals/index.md
+++ b/content/posts/empower-teams-with-sprint-goals/index.md
@@ -3,7 +3,7 @@ title: 'Empower Teams with Sprint Goals'
 slug: 'empower-teams-with-sprint-goals'
 draft: false
 publishDate: '2020-11-25'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["agile-and-scrum","team-health"]
 ---
 ![Empower Teams with Sprint Goals](images/bullet-journal-planning.jpg#center)

--- a/content/posts/empower-teams-with-sprint-goals/index.md
+++ b/content/posts/empower-teams-with-sprint-goals/index.md
@@ -4,7 +4,7 @@ slug: 'empower-teams-with-sprint-goals'
 draft: false
 publishDate: '2020-11-25'
 categories: ['General Musings']
-tags: ["Agile and Scrum","Team Health"]
+tags: ["agile-and-scrum","team-health"]
 ---
 ![Empower Teams with Sprint Goals](images/bullet-journal-planning.jpg#center)
 

--- a/content/posts/experiencing-the-duality-of-safety-considerations/index.md
+++ b/content/posts/experiencing-the-duality-of-safety-considerations/index.md
@@ -3,7 +3,8 @@ title: 'Experiencing the Duality of Safety Considerations'
 slug: 'experiencing-the-duality-of-safety-considerations'
 draft: false
 publishDate: '2024-07-24'
-tags: ['Gender', 'Transgender']
+categories: ["Personal Growth"]
+tags: ['gender', 'transgender']
 ---
 {{< figure
   src="images/pexels-steve-24031784.jpg"

--- a/content/posts/experiencing-the-duality-of-safety-considerations/index.md
+++ b/content/posts/experiencing-the-duality-of-safety-considerations/index.md
@@ -3,7 +3,7 @@ title: 'Experiencing the Duality of Safety Considerations'
 slug: 'experiencing-the-duality-of-safety-considerations'
 draft: false
 publishDate: '2024-07-24'
-categories: ["Personal Growth"]
+categories: ["Identity & Intersectionality"]
 tags: ['gender', 'transgender']
 ---
 {{< figure

--- a/content/posts/experiencing-the-duality-of-safety-considerations/index.md
+++ b/content/posts/experiencing-the-duality-of-safety-considerations/index.md
@@ -3,7 +3,7 @@ title: 'Experiencing the Duality of Safety Considerations'
 slug: 'experiencing-the-duality-of-safety-considerations'
 draft: false
 publishDate: '2024-07-24'
-categories: ["Identity & Intersectionality"]
+categories: ["identity-and-intersectionality"]
 tags: ['gender', 'transgender']
 ---
 {{< figure

--- a/content/posts/exploring-oregons-3-capes-scenic-loop/index.md
+++ b/content/posts/exploring-oregons-3-capes-scenic-loop/index.md
@@ -3,7 +3,7 @@ title: 'Exploring Oregons 3 Capes Scenic Loop'
 slug: 'exploring-oregons-3-capes-scenic'
 draft: false
 publishDate: '2024-10-15'
-tags: ["Ultra Endurance", "Cycling", "Ride Report"]
+tags: ["ultra-endurance", "cycling", "ride-report"]
 ---
 My cycling goals this year have revolved around a theme of trying new things and pushing myself in ways that had been relegated to the maybe some day category. This has included exploring gravel riding, racing, and ultra endurance. A few weeks ago I completed my third ultra endurance ride. I completed two 200km rides in the summer, but this was the first attempt at 300km. I've also longed to ride out to the Coast from Portland metro for years, but it always seemed out of reach. As Autumn rolled in and the days have already started getting shorter, I knew I had to commit now or face an increasing amount of time in the dark, and a higher chance of substantial rain. I enjoy riding in the dark hours and the rain, but those weren't variables I wanted at play with such a large increase in distance and total elevation.
 

--- a/content/posts/exploring-oregons-3-capes-scenic-loop/index.md
+++ b/content/posts/exploring-oregons-3-capes-scenic-loop/index.md
@@ -3,7 +3,7 @@ title: 'Exploring Oregons 3 Capes Scenic Loop'
 slug: 'exploring-oregons-3-capes-scenic'
 draft: false
 publishDate: '2024-10-15'
-categories: ["Sports & Recreation"]
+categories: ["sports-and-recreation"]
 tags: ["ultra-endurance", "cycling", "ride-report"]
 ---
 My cycling goals this year have revolved around a theme of trying new things and pushing myself in ways that had been relegated to the maybe some day category. This has included exploring gravel riding, racing, and ultra endurance. A few weeks ago I completed my third ultra endurance ride. I completed two 200km rides in the summer, but this was the first attempt at 300km. I've also longed to ride out to the Coast from Portland metro for years, but it always seemed out of reach. As Autumn rolled in and the days have already started getting shorter, I knew I had to commit now or face an increasing amount of time in the dark, and a higher chance of substantial rain. I enjoy riding in the dark hours and the rain, but those weren't variables I wanted at play with such a large increase in distance and total elevation.

--- a/content/posts/exploring-oregons-3-capes-scenic-loop/index.md
+++ b/content/posts/exploring-oregons-3-capes-scenic-loop/index.md
@@ -3,6 +3,7 @@ title: 'Exploring Oregons 3 Capes Scenic Loop'
 slug: 'exploring-oregons-3-capes-scenic'
 draft: false
 publishDate: '2024-10-15'
+categories: ["Sports & Recreation"]
 tags: ["ultra-endurance", "cycling", "ride-report"]
 ---
 My cycling goals this year have revolved around a theme of trying new things and pushing myself in ways that had been relegated to the maybe some day category. This has included exploring gravel riding, racing, and ultra endurance. A few weeks ago I completed my third ultra endurance ride. I completed two 200km rides in the summer, but this was the first attempt at 300km. I've also longed to ride out to the Coast from Portland metro for years, but it always seemed out of reach. As Autumn rolled in and the days have already started getting shorter, I knew I had to commit now or face an increasing amount of time in the dark, and a higher chance of substantial rain. I enjoy riding in the dark hours and the rain, but those weren't variables I wanted at play with such a large increase in distance and total elevation.

--- a/content/posts/fluidity/index.md
+++ b/content/posts/fluidity/index.md
@@ -3,7 +3,7 @@ title: 'Fluidity'
 slug: 'fluidity'
 draft: false
 publishDate: '2025-04-29'
-tags: ["Poetry", "Gender"]
+tags: ["poetry", "gender"]
 ---
 {{< figure
   src="images/pexels-anniroenkae-3109808.jpg"

--- a/content/posts/fluidity/index.md
+++ b/content/posts/fluidity/index.md
@@ -3,6 +3,7 @@ title: 'Fluidity'
 slug: 'fluidity'
 draft: false
 publishDate: '2025-04-29'
+categories: ["Creative Writing"]
 tags: ["poetry", "gender"]
 ---
 {{< figure

--- a/content/posts/functors-and-monads-30daysoffp-week-3/index.md
+++ b/content/posts/functors-and-monads-30daysoffp-week-3/index.md
@@ -4,7 +4,7 @@ slug: 'functors-and-monads-30daysoffp-week-3'
 draft: false
 publishDate: '2019-09-03'
 categories: ['Web Development']
-tags: ["functional-programming","javascript"]
+tags: ["functional-programming","JavaScript"]
 series: ['30 Days of Functional Programming']
 ---
 ![Functors and Monads - 30DaysofFP Week 3](images/abstract-water-rings.jpg#center)

--- a/content/posts/functors-and-monads-30daysoffp-week-3/index.md
+++ b/content/posts/functors-and-monads-30daysoffp-week-3/index.md
@@ -3,7 +3,7 @@ title: 'Functors and Monads - 30DaysofFP Week 3'
 slug: 'functors-and-monads-30daysoffp-week-3'
 draft: false
 publishDate: '2019-09-03'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ["functional-programming","JavaScript"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/functors-and-monads-30daysoffp-week-3/index.md
+++ b/content/posts/functors-and-monads-30daysoffp-week-3/index.md
@@ -3,7 +3,7 @@ title: 'Functors and Monads - 30DaysofFP Week 3'
 slug: 'functors-and-monads-30daysoffp-week-3'
 draft: false
 publishDate: '2019-09-03'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ["functional-programming","JavaScript"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/functors-and-monads-30daysoffp-week-3/index.md
+++ b/content/posts/functors-and-monads-30daysoffp-week-3/index.md
@@ -4,7 +4,7 @@ slug: 'functors-and-monads-30daysoffp-week-3'
 draft: false
 publishDate: '2019-09-03'
 categories: ['Web Development']
-tags: ["Functional Programming","JavaScript"]
+tags: ["functional-programming","javascript"]
 series: ['30 Days of Functional Programming']
 ---
 ![Functors and Monads - 30DaysofFP Week 3](images/abstract-water-rings.jpg#center)

--- a/content/posts/give-in-to-joy-and-beauty/index.md
+++ b/content/posts/give-in-to-joy-and-beauty/index.md
@@ -3,7 +3,7 @@ title: 'Give in to Joy and Beauty'
 slug: 'give-in-to-joy-and-beauty'
 draft: false
 publishDate: '2017-06-23'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ['Reflections']
 ---
 ![Hamilton Mountain](images/2017-06-hamilton-mountain.jpg)

--- a/content/posts/giving-ourselves-space-to-create/index.md
+++ b/content/posts/giving-ourselves-space-to-create/index.md
@@ -4,7 +4,7 @@ slug: 'giving-ourselves-space-to-create'
 draft: false
 publishDate: '2020-12-01'
 categories: ['General Musings']
-tags: ["Reflections","Creativity"]
+tags: ["reflections","creativity"]
 ---
 ![Giving Ourselves Space to Create](images/flower-amongst-lily-pads.jpg#center)
 

--- a/content/posts/giving-ourselves-space-to-create/index.md
+++ b/content/posts/giving-ourselves-space-to-create/index.md
@@ -3,7 +3,7 @@ title: 'Giving Ourselves Space to Create'
 slug: 'giving-ourselves-space-to-create'
 draft: false
 publishDate: '2020-12-01'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ["reflections","creativity"]
 ---
 ![Giving Ourselves Space to Create](images/flower-amongst-lily-pads.jpg#center)

--- a/content/posts/high-notification-rates-and-psychological-safety-decreasing-the-learning-curve/index.md
+++ b/content/posts/high-notification-rates-and-psychological-safety-decreasing-the-learning-curve/index.md
@@ -4,7 +4,7 @@ slug: 'high-notification-rates-and-psychological-safety-decreasing-the-learning-
 draft: false
 publishDate: '2020-12-22'
 categories: ['General Musings']
-tags: ["Team Health","Psychological Safety"]
+tags: ["team-health","psychological-safety"]
 ---
 ![High Notification Rates and Psychological Safety: Decreasing the Learning Curve](images/vintage-telephones.jpg#center)
 

--- a/content/posts/high-notification-rates-and-psychological-safety-decreasing-the-learning-curve/index.md
+++ b/content/posts/high-notification-rates-and-psychological-safety-decreasing-the-learning-curve/index.md
@@ -3,7 +3,7 @@ title: 'High Notification Rates and Psychological Safety: Decreasing the Learnin
 slug: 'high-notification-rates-and-psychological-safety-decreasing-the-learning-curve'
 draft: false
 publishDate: '2020-12-22'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["team-health","psychological-safety"]
 ---
 ![High Notification Rates and Psychological Safety: Decreasing the Learning Curve](images/vintage-telephones.jpg#center)

--- a/content/posts/how-allyship-shaped-my-participation-in-sports/index.md
+++ b/content/posts/how-allyship-shaped-my-participation-in-sports/index.md
@@ -4,7 +4,8 @@ slug: 'how-allyship-shaped-my-participation-in-sports'
 draft: false
 publishDate: '2024-06-11'
 summary: "It took a lot of internal reflection and discussions to recognize that my improving performance was due to the fact that I was steadily, and somewhat aggressively, increasing my training load. In retrospect, this seems obvious and the clearest answer, but the claws of societal transphobia had latched on deep."
-tags: ['Cycling', 'Transgender', 'Inclusion', 'Community']
+categories: ["Sports & Recreation"]
+tags: ['cycling', 'transgender', 'inclusion', 'community']
 ---
 ![Close up of a cyclist leg with a tattoo on the calf combining the trans symbol and a bike cog. Caption: It took a lot of internal reflection and discussions to recognize that my improving performance was due to the fact that I was steadily, and somewhat aggressively, increasing my training load. In retrospect, this seems obvious and the clearest answer, but the claws of societal transphobia had latched on deep.](images//cycling-tattoo-with-quote.jpg)
 

--- a/content/posts/how-allyship-shaped-my-participation-in-sports/index.md
+++ b/content/posts/how-allyship-shaped-my-participation-in-sports/index.md
@@ -4,7 +4,7 @@ slug: 'how-allyship-shaped-my-participation-in-sports'
 draft: false
 publishDate: '2024-06-11'
 summary: "It took a lot of internal reflection and discussions to recognize that my improving performance was due to the fact that I was steadily, and somewhat aggressively, increasing my training load. In retrospect, this seems obvious and the clearest answer, but the claws of societal transphobia had latched on deep."
-categories: ["Sports & Recreation"]
+categories: ["sports-and-recreation"]
 tags: ['cycling', 'transgender', 'inclusion', 'community']
 ---
 ![Close up of a cyclist leg with a tattoo on the calf combining the trans symbol and a bike cog. Caption: It took a lot of internal reflection and discussions to recognize that my improving performance was due to the fact that I was steadily, and somewhat aggressively, increasing my training load. In retrospect, this seems obvious and the clearest answer, but the claws of societal transphobia had latched on deep.](images//cycling-tattoo-with-quote.jpg)

--- a/content/posts/how-i-combined-two-blogging-platforms-in-20-hours/index.md
+++ b/content/posts/how-i-combined-two-blogging-platforms-in-20-hours/index.md
@@ -4,7 +4,7 @@ slug: how-i-combined-two-blogging-platforms-in-20-hours
 draft: false
 publishDate: 2025-05-19
 categories: ['Web Development']
-tags: [AI,Tooling,"Systems Design","Today I Learned","Projects","Refactoring"]
+tags: [AI,Tooling,"systems-design","today-i-learned","projects","refactoring"]
 ---
 You know those someday maybe projects, that sit in a doom pile in the mind while waiting to finally be discarded or surge in importance? One of my projects was finally consolidating two blogging platforms into one. I had previously built a portfolio site with Gatsby way back in the day—like 7 years ago when I mainly focused on front-end engineering. It had a bunch of technical and human skills posts that had largely been dormant since 2021. However, the posts about [TypeScript utility types](/tags/typescript/) still drive a lot of traffic to this day. I started writing again last year and wanted something that I could get up and running without having to worry about managing dependencies and fiddling with all of the little things. That was a quick way for me to get stuck in the minutiae, and not actually write. The content was also less technical, so I decided to separate it and spin up a Substack account.
 

--- a/content/posts/how-i-combined-two-blogging-platforms-in-20-hours/index.md
+++ b/content/posts/how-i-combined-two-blogging-platforms-in-20-hours/index.md
@@ -3,7 +3,7 @@ title: How I Combined Two Blogging Platforms in 20 Hours
 slug: how-i-combined-two-blogging-platforms-in-20-hours
 draft: false
 publishDate: 2025-05-19
-categories: ['Web Development']
+categories: ['Projects']
 tags: [AI,Tooling,"systems-design","today-i-learned","projects","refactoring"]
 ---
 You know those someday maybe projects, that sit in a doom pile in the mind while waiting to finally be discarded or surge in importance? One of my projects was finally consolidating two blogging platforms into one. I had previously built a portfolio site with Gatsby way back in the day—like 7 years ago when I mainly focused on front-end engineering. It had a bunch of technical and human skills posts that had largely been dormant since 2021. However, the posts about [TypeScript utility types](/tags/typescript/) still drive a lot of traffic to this day. I started writing again last year and wanted something that I could get up and running without having to worry about managing dependencies and fiddling with all of the little things. That was a quick way for me to get stuck in the minutiae, and not actually write. The content was also less technical, so I decided to separate it and spin up a Substack account.

--- a/content/posts/how-to-bundle-knex-with-webpack-for-serverless.md
+++ b/content/posts/how-to-bundle-knex-with-webpack-for-serverless.md
@@ -4,7 +4,7 @@ slug: 'how-to-bundle-knex-with-webpack-for-serverless'
 draft: false
 publishDate: '2020-05-22'
 categories: ['Web Development']
-tags: ["Today I Learned","Tooling"]
+tags: ["today-i-learned","tooling"]
 ---
 Bundling [Knex](http://knexjs.org/) with Webpack doesn't always play well. In this particular case I was trying to bundle a serverless application with only the runtime dependencies. Since this project was utilizing TypeScript and other tooling and dev-dependencies I definitely did not want to ship all of the node modules. Additionally, most of the 10 module resolution errors I was receiving were for packages I didn't even have installed. In this blog post we'll cover utilizing a Webpack plugin to resolve this build error.
 

--- a/content/posts/how-to-bundle-knex-with-webpack-for-serverless.md
+++ b/content/posts/how-to-bundle-knex-with-webpack-for-serverless.md
@@ -3,7 +3,7 @@ title: 'How to Bundle Knex with Webpack for Serverless'
 slug: 'how-to-bundle-knex-with-webpack-for-serverless'
 draft: false
 publishDate: '2020-05-22'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["today-i-learned","tooling"]
 ---
 Bundling [Knex](http://knexjs.org/) with Webpack doesn't always play well. In this particular case I was trying to bundle a serverless application with only the runtime dependencies. Since this project was utilizing TypeScript and other tooling and dev-dependencies I definitely did not want to ship all of the node modules. Additionally, most of the 10 module resolution errors I was receiving were for packages I didn't even have installed. In this blog post we'll cover utilizing a Webpack plugin to resolve this build error.

--- a/content/posts/how-to-configure-jest-for-vue-apps-using-vuetify/index.md
+++ b/content/posts/how-to-configure-jest-for-vue-apps-using-vuetify/index.md
@@ -4,7 +4,7 @@ slug: 'how-to-configure-jest-for-vue-apps-using-vuetify'
 draft: false
 publishDate: '2019-10-09'
 categories: ['Web Development']
-tags: ["Today I Learned","Testing","Tooling"]
+tags: ["today-i-learned","testing","tooling"]
 ---
 ![How to Configure Jest for Vue apps Using Vuetify](images/abstract-pink-blue-connections.jpg#center)
 

--- a/content/posts/how-to-configure-jest-for-vue-apps-using-vuetify/index.md
+++ b/content/posts/how-to-configure-jest-for-vue-apps-using-vuetify/index.md
@@ -3,7 +3,7 @@ title: 'How to Configure Jest for Vue apps Using Vuetify'
 slug: 'how-to-configure-jest-for-vue-apps-using-vuetify'
 draft: false
 publishDate: '2019-10-09'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["today-i-learned","testing","tooling"]
 ---
 ![How to Configure Jest for Vue apps Using Vuetify](images/abstract-pink-blue-connections.jpg#center)

--- a/content/posts/how-to-manage-dependencies-with-confidence/index.md
+++ b/content/posts/how-to-manage-dependencies-with-confidence/index.md
@@ -4,7 +4,7 @@ slug: 'how-to-manage-dependencies-with-confidence'
 draft: false
 publishDate: '2019-02-25'
 categories: ['Web Development']
-tags: ["Tooling","NPM"]
+tags: ["tooling","npm"]
 ---
 ![How to Manage Dependencies with Confidence](images/2019-02-balanced-rocks.jpg#center)
 

--- a/content/posts/how-to-manage-dependencies-with-confidence/index.md
+++ b/content/posts/how-to-manage-dependencies-with-confidence/index.md
@@ -3,7 +3,7 @@ title: 'How to Manage Dependencies with Confidence'
 slug: 'how-to-manage-dependencies-with-confidence'
 draft: false
 publishDate: '2019-02-25'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["tooling","npm"]
 ---
 ![How to Manage Dependencies with Confidence](images/2019-02-balanced-rocks.jpg#center)

--- a/content/posts/how-to-manage-snapshots-with-eslint/index.md
+++ b/content/posts/how-to-manage-snapshots-with-eslint/index.md
@@ -3,7 +3,7 @@ title: 'How to Manage Snapshots with ESLint'
 slug: 'how-to-manage-snapshots-with-eslint'
 draft: false
 publishDate: '2019-03-18'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["testing","tooling","linting","code-quality"]
 ---
 ![How to Manage Snapshots with ESLint](images/paul-skorupskas-snapshot.jpg#center)

--- a/content/posts/how-to-manage-snapshots-with-eslint/index.md
+++ b/content/posts/how-to-manage-snapshots-with-eslint/index.md
@@ -4,7 +4,7 @@ slug: 'how-to-manage-snapshots-with-eslint'
 draft: false
 publishDate: '2019-03-18'
 categories: ['Web Development']
-tags: ["Testing","Tooling","Linting","Code Quality"]
+tags: ["testing","tooling","linting","code-quality"]
 ---
 ![How to Manage Snapshots with ESLint](images/paul-skorupskas-snapshot.jpg#center)
 

--- a/content/posts/how-to-resolve-accessibility-issues-with-react-helmet/index.md
+++ b/content/posts/how-to-resolve-accessibility-issues-with-react-helmet/index.md
@@ -3,7 +3,7 @@ title: 'How to Resolve Accessibility Issues with React Helmet'
 slug: 'how-to-resolve-accessibility-issues-with-react-helmet'
 draft: false
 publishDate: '2019-05-28'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["react","accessibility"]
 ---
 ![How to Resolve Accessibility Issues with React Helmet](images/book-reading-with-coffee.jpg#center)

--- a/content/posts/how-to-resolve-accessibility-issues-with-react-helmet/index.md
+++ b/content/posts/how-to-resolve-accessibility-issues-with-react-helmet/index.md
@@ -4,7 +4,7 @@ slug: 'how-to-resolve-accessibility-issues-with-react-helmet'
 draft: false
 publishDate: '2019-05-28'
 categories: ['Web Development']
-tags: ["React","Accessibility"]
+tags: ["react","accessibility"]
 ---
 ![How to Resolve Accessibility Issues with React Helmet](images/book-reading-with-coffee.jpg#center)
 

--- a/content/posts/intersectional-survival.md
+++ b/content/posts/intersectional-survival.md
@@ -4,6 +4,7 @@ slug: 'intersectional-survival'
 description: "What other option is there?"
 draft: false
 publishDate: '2025-03-29'
+categories: ["Creative Writing"]
 tags: ["transgender", "poetry", "neurodiversity", "mental-health"]
 ---
 I look in the mirror and wonder\

--- a/content/posts/intersectional-survival.md
+++ b/content/posts/intersectional-survival.md
@@ -4,7 +4,7 @@ slug: 'intersectional-survival'
 description: "What other option is there?"
 draft: false
 publishDate: '2025-03-29'
-tags: ["Transgender", "Poetry", "Neurodiversity", "Mental Health"]
+tags: ["transgender", "poetry", "neurodiversity", "mental-health"]
 ---
 I look in the mirror and wonder\
 How can so little be done\

--- a/content/posts/iterating-quickly-with-graphql-and-gatsby/index.md
+++ b/content/posts/iterating-quickly-with-graphql-and-gatsby/index.md
@@ -3,7 +3,7 @@ title: 'Iterating Quickly with GraphQL and Gatsby'
 slug: 'iterating-quickly-with-graphql-and-gatsby'
 draft: false
 publishDate: '2019-03-11'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["GraphQL","gatsby","tooling"]
 ---
 ![Iterating Quickly with GraphQL and Gatsby](images/geometric-triangles.jpg#center)

--- a/content/posts/iterating-quickly-with-graphql-and-gatsby/index.md
+++ b/content/posts/iterating-quickly-with-graphql-and-gatsby/index.md
@@ -4,7 +4,7 @@ slug: 'iterating-quickly-with-graphql-and-gatsby'
 draft: false
 publishDate: '2019-03-11'
 categories: ['Web Development']
-tags: ["GraphQL","Gatsby","Tooling"]
+tags: ["graphql","gatsby","tooling"]
 ---
 ![Iterating Quickly with GraphQL and Gatsby](images/geometric-triangles.jpg#center)
 

--- a/content/posts/iterating-quickly-with-graphql-and-gatsby/index.md
+++ b/content/posts/iterating-quickly-with-graphql-and-gatsby/index.md
@@ -4,7 +4,7 @@ slug: 'iterating-quickly-with-graphql-and-gatsby'
 draft: false
 publishDate: '2019-03-11'
 categories: ['Web Development']
-tags: ["graphql","gatsby","tooling"]
+tags: ["GraphQL","gatsby","tooling"]
 ---
 ![Iterating Quickly with GraphQL and Gatsby](images/geometric-triangles.jpg#center)
 

--- a/content/posts/javascript-calculator-my-first-react-project/index.md
+++ b/content/posts/javascript-calculator-my-first-react-project/index.md
@@ -3,7 +3,7 @@ title: 'JavaScript Calculator: my First React Project'
 slug: 'javascript-calculator-my-first-react-project'
 draft: false
 publishDate: '2017-08-06'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ['Projects']
 ---
 ![JavaScript Calculator](images/2017-08-javascript-calculator-v1.jpg)

--- a/content/posts/javascript-calculator-my-first-react-project/index.md
+++ b/content/posts/javascript-calculator-my-first-react-project/index.md
@@ -4,7 +4,7 @@ slug: 'javascript-calculator-my-first-react-project'
 draft: false
 publishDate: '2017-08-06'
 categories: ['Projects']
-tags: ['Projects']
+tags: ['react', 'JavaScript', 'learning']
 ---
 ![JavaScript Calculator](images/2017-08-javascript-calculator-v1.jpg)
 

--- a/content/posts/linked-list-20190729.md
+++ b/content/posts/linked-list-20190729.md
@@ -3,7 +3,7 @@ title: 'Linked List - 20190729'
 slug: 'linked-list-20190729'
 draft: false
 publishDate: '2019-07-29'
-categories: ['Linked List']
+categories: ['Resources']
 tags: ["accessibility","GraphQL","web-development","JavaScript"]
 ---
 The Linked List is a collection of interesting articles that I have recently read and found beneficial. Today's links cover web accessibility, upcoming features to ECMAScript, breaking down imperative vs declarative programming, and why your GraphQL APIs should embrace nullability.

--- a/content/posts/linked-list-20190729.md
+++ b/content/posts/linked-list-20190729.md
@@ -4,7 +4,7 @@ slug: 'linked-list-20190729'
 draft: false
 publishDate: '2019-07-29'
 categories: ['Linked List']
-tags: ["accessibility","graphql","web-development","javascript"]
+tags: ["accessibility","GraphQL","web-development","JavaScript"]
 ---
 The Linked List is a collection of interesting articles that I have recently read and found beneficial. Today's links cover web accessibility, upcoming features to ECMAScript, breaking down imperative vs declarative programming, and why your GraphQL APIs should embrace nullability.
 

--- a/content/posts/linked-list-20190729.md
+++ b/content/posts/linked-list-20190729.md
@@ -4,7 +4,7 @@ slug: 'linked-list-20190729'
 draft: false
 publishDate: '2019-07-29'
 categories: ['Linked List']
-tags: ["Accessibility","GraphQL","Web Development","JavaScript"]
+tags: ["accessibility","graphql","web-development","javascript"]
 ---
 The Linked List is a collection of interesting articles that I have recently read and found beneficial. Today's links cover web accessibility, upcoming features to ECMAScript, breaking down imperative vs declarative programming, and why your GraphQL APIs should embrace nullability.
 

--- a/content/posts/linked-list-20190822.md
+++ b/content/posts/linked-list-20190822.md
@@ -4,7 +4,7 @@ slug: 'linked-list-20190822'
 draft: false
 publishDate: '2019-08-22'
 categories: ['Linked List']
-tags: ["accessibility","react-hooks","typescript"]
+tags: ["accessibility","react-hooks","TypeScript"]
 ---
 The Linked List is a collection of interesting articles that I have recently read and found beneficial. Today's links cover web accessibility, TypeScript adoption, and React Hooks.
 

--- a/content/posts/linked-list-20190822.md
+++ b/content/posts/linked-list-20190822.md
@@ -3,7 +3,7 @@ title: 'Linked List - 20190822'
 slug: 'linked-list-20190822'
 draft: false
 publishDate: '2019-08-22'
-categories: ['Linked List']
+categories: ['Resources']
 tags: ["accessibility","react-hooks","TypeScript"]
 ---
 The Linked List is a collection of interesting articles that I have recently read and found beneficial. Today's links cover web accessibility, TypeScript adoption, and React Hooks.

--- a/content/posts/linked-list-20190822.md
+++ b/content/posts/linked-list-20190822.md
@@ -4,7 +4,7 @@ slug: 'linked-list-20190822'
 draft: false
 publishDate: '2019-08-22'
 categories: ['Linked List']
-tags: ["Accessibility","React Hooks","TypeScript"]
+tags: ["accessibility","react-hooks","typescript"]
 ---
 The Linked List is a collection of interesting articles that I have recently read and found beneficial. Today's links cover web accessibility, TypeScript adoption, and React Hooks.
 

--- a/content/posts/nevertheless-they-persisted/index.md
+++ b/content/posts/nevertheless-they-persisted/index.md
@@ -3,7 +3,7 @@ title: 'Nevertheless They Persisted'
 slug: 'nevertheless-they-persisted'
 draft: false
 publishDate: '2025-01-30'
-categories: ["Creative Writing"]
+categories: ["Identity & Intersectionality"]
 tags: ["gender", "transgender", "history"]
 ---
 {{< figure

--- a/content/posts/nevertheless-they-persisted/index.md
+++ b/content/posts/nevertheless-they-persisted/index.md
@@ -3,7 +3,7 @@ title: 'Nevertheless They Persisted'
 slug: 'nevertheless-they-persisted'
 draft: false
 publishDate: '2025-01-30'
-categories: ["Identity & Intersectionality"]
+categories: ["identity-and-intersectionality"]
 tags: ["gender", "transgender", "history"]
 ---
 {{< figure

--- a/content/posts/nevertheless-they-persisted/index.md
+++ b/content/posts/nevertheless-they-persisted/index.md
@@ -3,6 +3,7 @@ title: 'Nevertheless They Persisted'
 slug: 'nevertheless-they-persisted'
 draft: false
 publishDate: '2025-01-30'
+categories: ["Creative Writing"]
 tags: ["gender", "transgender", "history"]
 ---
 {{< figure

--- a/content/posts/nevertheless-they-persisted/index.md
+++ b/content/posts/nevertheless-they-persisted/index.md
@@ -3,7 +3,7 @@ title: 'Nevertheless They Persisted'
 slug: 'nevertheless-they-persisted'
 draft: false
 publishDate: '2025-01-30'
-tags: ["Gender", "Transgender", "History"]
+tags: ["gender", "transgender", "history"]
 ---
 {{< figure
   src="images/pain-graphic.jpg"

--- a/content/posts/overcoming-the-fragility-of-goals-with-themes/index.md
+++ b/content/posts/overcoming-the-fragility-of-goals-with-themes/index.md
@@ -4,7 +4,7 @@ slug: 'overcoming-the-fragility-of-goals-with-themes'
 draft: false
 publishDate: '2020-11-30'
 categories: ['General Musings']
-tags: ["Reflections","Themes"]
+tags: ["reflections","themes"]
 ---
 ![Overcoming the Fragility of Goals with Themes](images/people-light-exhibit.jpg#center)
 

--- a/content/posts/overcoming-the-fragility-of-goals-with-themes/index.md
+++ b/content/posts/overcoming-the-fragility-of-goals-with-themes/index.md
@@ -3,7 +3,7 @@ title: 'Overcoming the Fragility of Goals with Themes'
 slug: 'overcoming-the-fragility-of-goals-with-themes'
 draft: false
 publishDate: '2020-11-30'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ["reflections","themes"]
 ---
 ![Overcoming the Fragility of Goals with Themes](images/people-light-exhibit.jpg#center)

--- a/content/posts/personal-retrospective-q2-2019.md
+++ b/content/posts/personal-retrospective-q2-2019.md
@@ -3,7 +3,7 @@ title: 'Personal Retrospective: Q2 2019'
 slug: 'personal-retrospective-q2-2019'
 draft: false
 publishDate: '2019-08-05'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ["reflections","retrospectives"]
 ---
 Retrospectives, when done well, can have a great impact on team environments and allow for various adjustments. These checkins become pivoting and adapting catalysts. Recently, I have been doing some self exploration leading to the desire for more [focused learning](/blog/2019/08/01/30-days-of-functional-programming). In talking with other developers and taking inspiration from [Jason Lengstorf](https://lengstorf.com/2019-q1-retrospective/), I have decided to take on quarterly personal retrospectives.

--- a/content/posts/personal-retrospective-q2-2019.md
+++ b/content/posts/personal-retrospective-q2-2019.md
@@ -4,7 +4,7 @@ slug: 'personal-retrospective-q2-2019'
 draft: false
 publishDate: '2019-08-05'
 categories: ['General Musings']
-tags: ["Reflections","Retrospectives"]
+tags: ["reflections","retrospectives"]
 ---
 Retrospectives, when done well, can have a great impact on team environments and allow for various adjustments. These checkins become pivoting and adapting catalysts. Recently, I have been doing some self exploration leading to the desire for more [focused learning](/blog/2019/08/01/30-days-of-functional-programming). In talking with other developers and taking inspiration from [Jason Lengstorf](https://lengstorf.com/2019-q1-retrospective/), I have decided to take on quarterly personal retrospectives.
 

--- a/content/posts/personal-retrospective-q3-2019/index.md
+++ b/content/posts/personal-retrospective-q3-2019/index.md
@@ -4,7 +4,7 @@ slug: 'personal-retrospective-q3-2019'
 draft: false
 publishDate: '2019-10-23'
 categories: ['General Musings']
-tags: ["Retrospectives","Reflections"]
+tags: ["retrospectives","reflections"]
 ---
 ![Personal Retrospective: Q3 2019](images/meiying-ng-iB7gjOsLrEQ-unsplash.jpg#center)
 

--- a/content/posts/personal-retrospective-q3-2019/index.md
+++ b/content/posts/personal-retrospective-q3-2019/index.md
@@ -3,7 +3,7 @@ title: 'Personal Retrospective: Q3 2019'
 slug: 'personal-retrospective-q3-2019'
 draft: false
 publishDate: '2019-10-23'
-categories: ['General Musings']
+categories: ['Personal Growth']
 tags: ["retrospectives","reflections"]
 ---
 ![Personal Retrospective: Q3 2019](images/meiying-ng-iB7gjOsLrEQ-unsplash.jpg#center)

--- a/content/posts/pragmatic-lessons-from-converting-to-react-hooks/index.md
+++ b/content/posts/pragmatic-lessons-from-converting-to-react-hooks/index.md
@@ -3,7 +3,7 @@ title: 'Pragmatic Lessons from Converting to React Hooks'
 slug: 'pragmatic-lessons-from-converting-to-react-hooks'
 draft: false
 publishDate: '2019-02-06'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["react","projects","react-hooks","gatsby","refactoring","learning"]
 ---
 ![Pragmatic Lessons from Converting to React Hooks](images/2019-02-hooks-diff.jpg#center)

--- a/content/posts/pragmatic-lessons-from-converting-to-react-hooks/index.md
+++ b/content/posts/pragmatic-lessons-from-converting-to-react-hooks/index.md
@@ -4,7 +4,7 @@ slug: 'pragmatic-lessons-from-converting-to-react-hooks'
 draft: false
 publishDate: '2019-02-06'
 categories: ['Web Development']
-tags: ["React","Projects","React Hooks","Gatsby","Refactoring","Learning"]
+tags: ["react","projects","react-hooks","gatsby","refactoring","learning"]
 ---
 ![Pragmatic Lessons from Converting to React Hooks](images/2019-02-hooks-diff.jpg#center)
 

--- a/content/posts/pragmatic-uses-for-react-context/index.md
+++ b/content/posts/pragmatic-uses-for-react-context/index.md
@@ -4,7 +4,7 @@ slug: 'pragmatic-uses-for-react-context'
 draft: false
 publishDate: '2019-07-24'
 categories: ['Web Development']
-tags: ["React","React Hooks"]
+tags: ["react","react-hooks"]
 ---
 ![Pragmatic uses for React Context](images/chains-perspective.jpg#center)
 

--- a/content/posts/pragmatic-uses-for-react-context/index.md
+++ b/content/posts/pragmatic-uses-for-react-context/index.md
@@ -3,7 +3,7 @@ title: 'Pragmatic uses for React Context'
 slug: 'pragmatic-uses-for-react-context'
 draft: false
 publishDate: '2019-07-24'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["react","react-hooks"]
 ---
 ![Pragmatic uses for React Context](images/chains-perspective.jpg#center)

--- a/content/posts/queer-solidarity-and-the-impact-of-visibility-tanking/index.md
+++ b/content/posts/queer-solidarity-and-the-impact-of-visibility-tanking/index.md
@@ -3,7 +3,7 @@ title: 'Queer Solidarity and the Impact of Visibility Tanking'
 slug: 'queer-solidarity-and-the-impact-of-visibility-tanking'
 draft: false
 publishDate: '2025-01-13'
-categories: ["Identity & Intersectionality"]
+categories: ["identity-and-intersectionality"]
 tags: ['history', 'transgender', 'gender']
 ---
 {{< figure

--- a/content/posts/queer-solidarity-and-the-impact-of-visibility-tanking/index.md
+++ b/content/posts/queer-solidarity-and-the-impact-of-visibility-tanking/index.md
@@ -3,7 +3,7 @@ title: 'Queer Solidarity and the Impact of Visibility Tanking'
 slug: 'queer-solidarity-and-the-impact-of-visibility-tanking'
 draft: false
 publishDate: '2025-01-13'
-categories: ["Personal Growth"]
+categories: ["Identity & Intersectionality"]
 tags: ['history', 'transgender', 'gender']
 ---
 {{< figure

--- a/content/posts/queer-solidarity-and-the-impact-of-visibility-tanking/index.md
+++ b/content/posts/queer-solidarity-and-the-impact-of-visibility-tanking/index.md
@@ -3,7 +3,8 @@ title: 'Queer Solidarity and the Impact of Visibility Tanking'
 slug: 'queer-solidarity-and-the-impact-of-visibility-tanking'
 draft: false
 publishDate: '2025-01-13'
-tags: ['History', 'Transgender', 'Gender']
+categories: ["Personal Growth"]
+tags: ['history', 'transgender', 'gender']
 ---
 {{< figure
   src="images/kitty-donor.jpeg"

--- a/content/posts/serendipitous-collaboration-in-unlikely-places/index.md
+++ b/content/posts/serendipitous-collaboration-in-unlikely-places/index.md
@@ -3,7 +3,7 @@ title: 'Serendipitous Collaboration in Unlikely Places'
 slug: 'serendipitous-collaboration-in-unlikely-places'
 draft: false
 publishDate: '2020-12-30'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["team-health","psychological-safety","creativity"]
 ---
 ![Serendipitous Collaboration in Unlikely Places](images/lego-minifigs-looking-away.jpg#center)

--- a/content/posts/serendipitous-collaboration-in-unlikely-places/index.md
+++ b/content/posts/serendipitous-collaboration-in-unlikely-places/index.md
@@ -4,7 +4,7 @@ slug: 'serendipitous-collaboration-in-unlikely-places'
 draft: false
 publishDate: '2020-12-30'
 categories: ['General Musings']
-tags: ["Team Health","Psychological Safety","Creativity"]
+tags: ["team-health","psychological-safety","creativity"]
 ---
 ![Serendipitous Collaboration in Unlikely Places](images/lego-minifigs-looking-away.jpg#center)
 

--- a/content/posts/shaping-javascript-usage-with-eslint/index.md
+++ b/content/posts/shaping-javascript-usage-with-eslint/index.md
@@ -4,7 +4,7 @@ slug: 'shaping-javascript-usage-with-eslint'
 draft: false
 publishDate: '2019-05-23'
 categories: ['Web Development']
-tags: ["Tooling","Linting","Accessibility"]
+tags: ["tooling","linting","accessibility"]
 ---
 ![Shaping JavaScript Usage with ESLint](images/shaping-pottery.jpg#center)
 

--- a/content/posts/shaping-javascript-usage-with-eslint/index.md
+++ b/content/posts/shaping-javascript-usage-with-eslint/index.md
@@ -3,7 +3,7 @@ title: 'Shaping JavaScript Usage with ESLint'
 slug: 'shaping-javascript-usage-with-eslint'
 draft: false
 publishDate: '2019-05-23'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["tooling","linting","accessibility"]
 ---
 ![Shaping JavaScript Usage with ESLint](images/shaping-pottery.jpg#center)

--- a/content/posts/tailwindcss-from-skeptic-to-advocate/index.md
+++ b/content/posts/tailwindcss-from-skeptic-to-advocate/index.md
@@ -4,7 +4,7 @@ slug: 'tailwindcss-from-skeptic-to-advocate'
 draft: false
 publishDate: '2020-05-18'
 categories: ['Web Development']
-tags: ["CSS","Tooling","Systems Design"]
+tags: ["css","tooling","systems-design"]
 ---
 ![TailwindCSS: From Skeptic to Advocate](images/abstract-blue-peach-ripples.jpg#center)
 

--- a/content/posts/tailwindcss-from-skeptic-to-advocate/index.md
+++ b/content/posts/tailwindcss-from-skeptic-to-advocate/index.md
@@ -4,7 +4,7 @@ slug: 'tailwindcss-from-skeptic-to-advocate'
 draft: false
 publishDate: '2020-05-18'
 categories: ['Web Development']
-tags: ["css","tooling","systems-design"]
+tags: ["CSS","tooling","systems-design"]
 ---
 ![TailwindCSS: From Skeptic to Advocate](images/abstract-blue-peach-ripples.jpg#center)
 

--- a/content/posts/tailwindcss-from-skeptic-to-advocate/index.md
+++ b/content/posts/tailwindcss-from-skeptic-to-advocate/index.md
@@ -3,7 +3,7 @@ title: 'TailwindCSS: From Skeptic to Advocate'
 slug: 'tailwindcss-from-skeptic-to-advocate'
 draft: false
 publishDate: '2020-05-18'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["CSS","tooling","systems-design"]
 ---
 ![TailwindCSS: From Skeptic to Advocate](images/abstract-blue-peach-ripples.jpg#center)

--- a/content/posts/the-439-day-journey-that-changed-my-life/index.md
+++ b/content/posts/the-439-day-journey-that-changed-my-life/index.md
@@ -3,7 +3,7 @@ title: 'The 439 day Journey that Changed my Life'
 slug: 'the-439-day-journey-that-changed-my-life'
 draft: false
 publishDate: '2018-09-10'
-categories: ['Web Development']
+categories: ['Personal Growth']
 tags: ["reflections","personal-growth","learning"]
 ---
 ![The 439 day Journey that Changed my Life](images/2018-08-nighttime-timelapse.jpg#center)

--- a/content/posts/the-439-day-journey-that-changed-my-life/index.md
+++ b/content/posts/the-439-day-journey-that-changed-my-life/index.md
@@ -4,7 +4,7 @@ slug: 'the-439-day-journey-that-changed-my-life'
 draft: false
 publishDate: '2018-09-10'
 categories: ['Web Development']
-tags: ["Reflections","Personal Growth","Learning"]
+tags: ["reflections","personal-growth","learning"]
 ---
 ![The 439 day Journey that Changed my Life](images/2018-08-nighttime-timelapse.jpg#center)
 

--- a/content/posts/the-completion-of-30-days-of-functional-programming/index.md
+++ b/content/posts/the-completion-of-30-days-of-functional-programming/index.md
@@ -3,7 +3,7 @@ title: 'The Completion of 30 Days of Functional Programming'
 slug: 'the-completion-of-30-days-of-functional-programming'
 draft: false
 publishDate: '2019-09-05'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/the-completion-of-30-days-of-functional-programming/index.md
+++ b/content/posts/the-completion-of-30-days-of-functional-programming/index.md
@@ -4,7 +4,7 @@ slug: 'the-completion-of-30-days-of-functional-programming'
 draft: false
 publishDate: '2019-09-05'
 categories: ['Web Development']
-tags: ["Functional Programming"]
+tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---
 ![The Completion of 30 Days of Functional Programming](images/foggy-lake-tree-reflection.jpg#center)

--- a/content/posts/the-completion-of-30-days-of-functional-programming/index.md
+++ b/content/posts/the-completion-of-30-days-of-functional-programming/index.md
@@ -3,7 +3,7 @@ title: 'The Completion of 30 Days of Functional Programming'
 slug: 'the-completion-of-30-days-of-functional-programming'
 draft: false
 publishDate: '2019-09-05'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/the-excitement-of-releasing-a-new-project/index.md
+++ b/content/posts/the-excitement-of-releasing-a-new-project/index.md
@@ -3,7 +3,7 @@ title: 'The Excitement of Releasing a New Project'
 slug: 'the-excitement-of-releasing-a-new-project'
 draft: false
 publishDate: '2017-06-14'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ['Projects']
 ---
 ![](images/2017-06-twitch-code.jpg)

--- a/content/posts/the-importance-of-creating-psychological-safety/index.md
+++ b/content/posts/the-importance-of-creating-psychological-safety/index.md
@@ -4,7 +4,7 @@ slug: 'the-importance-of-creating-psychological-safety'
 draft: false
 publishDate: '2020-12-07'
 categories: ['General Musings']
-tags: ["Psychological Safety","Team Health","Leadership","Organizational Culture"]
+tags: ["psychological-safety","team-health","leadership","organizational-culture"]
 ---
 ![The Importance of Creating Psychological Safety](images/oceanside-stacked-rocks.jpg#center)
 

--- a/content/posts/the-importance-of-creating-psychological-safety/index.md
+++ b/content/posts/the-importance-of-creating-psychological-safety/index.md
@@ -3,7 +3,7 @@ title: 'The Importance of Creating Psychological Safety'
 slug: 'the-importance-of-creating-psychological-safety'
 draft: false
 publishDate: '2020-12-07'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["psychological-safety","team-health","leadership","organizational-culture"]
 ---
 ![The Importance of Creating Psychological Safety](images/oceanside-stacked-rocks.jpg#center)

--- a/content/posts/the-journey-to-creating-wanderful/index.md
+++ b/content/posts/the-journey-to-creating-wanderful/index.md
@@ -4,7 +4,7 @@ slug: 'the-journey-to-creating-wanderful'
 draft: false
 publishDate: '2017-11-21'
 categories: ['Web Development']
-tags: ["Reflections","Projects"]
+tags: ["reflections","projects"]
 ---
 ![The Journey to Creating Wanderful](images/2017-11-wanderful-v1.jpg#center)
 

--- a/content/posts/the-journey-to-creating-wanderful/index.md
+++ b/content/posts/the-journey-to-creating-wanderful/index.md
@@ -3,7 +3,7 @@ title: 'The Journey to Creating Wanderful'
 slug: 'the-journey-to-creating-wanderful'
 draft: false
 publishDate: '2017-11-21'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ["reflections","projects"]
 ---
 ![The Journey to Creating Wanderful](images/2017-11-wanderful-v1.jpg#center)

--- a/content/posts/the-prompt-and-subtle-infiltration-of-imposter-syndrome/index.md
+++ b/content/posts/the-prompt-and-subtle-infiltration-of-imposter-syndrome/index.md
@@ -3,7 +3,7 @@ title: 'The Prompt and Subtle Infiltration of Imposter Syndrome'
 slug: 'the-prompt-and-subtle-infiltration-of-imposter-syndrome'
 draft: false
 publishDate: '2017-06-02'
-categories: ['Web Development']
+categories: ['Personal Growth']
 tags: []
 ---
 ![Computer and coffee](images/2017-05-computer-coffee.jpg)

--- a/content/posts/the-prompt-and-subtle-infiltration-of-imposter-syndrome/index.md
+++ b/content/posts/the-prompt-and-subtle-infiltration-of-imposter-syndrome/index.md
@@ -4,7 +4,7 @@ slug: 'the-prompt-and-subtle-infiltration-of-imposter-syndrome'
 draft: false
 publishDate: '2017-06-02'
 categories: ['Personal Growth']
-tags: []
+tags: ['reflections', 'learning']
 ---
 ![Computer and coffee](images/2017-05-computer-coffee.jpg)
 

--- a/content/posts/the-start-of-100daysofcode.md
+++ b/content/posts/the-start-of-100daysofcode.md
@@ -3,7 +3,7 @@ title: 'The Start of #100DaysOfCode'
 slug: 'the-start-of-100daysofcode'
 draft: false
 publishDate: '2017-08-07'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 series: ['100 Days of Code']
 ---
 > The act of monitoring waypoints and milestones is important to recognize and celebrate.

--- a/content/posts/the-start-of-100daysofcode.md
+++ b/content/posts/the-start-of-100daysofcode.md
@@ -3,7 +3,7 @@ title: 'The Start of #100DaysOfCode'
 slug: 'the-start-of-100daysofcode'
 draft: false
 publishDate: '2017-08-07'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 series: ['100 Days of Code']
 ---
 > The act of monitoring waypoints and milestones is important to recognize and celebrate.

--- a/content/posts/things-dont-always-make-sense.md
+++ b/content/posts/things-dont-always-make-sense.md
@@ -3,7 +3,7 @@ title: "Things Don't Always Make Sense"
 slug: 'things-dont-always-make-sense'
 draft: false
 publishDate: '2025-05-12'
-tags: ["Poetry"]
+tags: ["poetry"]
 ---
 Things don't always make sense. People are impacted by painful circumstances differently. They manifest in different ways. Our communities still come together.
 

--- a/content/posts/things-dont-always-make-sense.md
+++ b/content/posts/things-dont-always-make-sense.md
@@ -4,7 +4,7 @@ slug: 'things-dont-always-make-sense'
 draft: false
 publishDate: '2025-05-12'
 categories: ["Creative Writing"]
-tags: ["poetry"]
+tags: ['poetry', 'community']
 ---
 Things don't always make sense. People are impacted by painful circumstances differently. They manifest in different ways. Our communities still come together.
 

--- a/content/posts/things-dont-always-make-sense.md
+++ b/content/posts/things-dont-always-make-sense.md
@@ -3,6 +3,7 @@ title: "Things Don't Always Make Sense"
 slug: 'things-dont-always-make-sense'
 draft: false
 publishDate: '2025-05-12'
+categories: ["Creative Writing"]
 tags: ["poetry"]
 ---
 Things don't always make sense. People are impacted by painful circumstances differently. They manifest in different ways. Our communities still come together.

--- a/content/posts/three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations.md
+++ b/content/posts/three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations.md
@@ -3,7 +3,7 @@ title: 'Three Lessons Learned from Overcoming the Inertia Against Technical Pres
 slug: 'three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations'
 draft: false
 publishDate: '2018-05-17'
-categories: ['Web Development']
+categories: ['Career Development']
 tags: ["reflections"]
 ---
 > You don’t need to be an expert to teach others, even teaching people who have more overall experience than you do. The matter that someone has a wider breath of experience overall does not equate to knowing a particular system in depth.

--- a/content/posts/three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations.md
+++ b/content/posts/three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations.md
@@ -4,7 +4,7 @@ slug: 'three-lessons-learned-from-overcoming-the-inertia-against-technical-prese
 draft: false
 publishDate: '2018-05-17'
 categories: ['Career Development']
-tags: ["reflections"]
+tags: ['reflections', 'GraphQL', 'community']
 ---
 > You don’t need to be an expert to teach others, even teaching people who have more overall experience than you do. The matter that someone has a wider breath of experience overall does not equate to knowing a particular system in depth.
 

--- a/content/posts/three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations.md
+++ b/content/posts/three-lessons-learned-from-overcoming-the-inertia-against-technical-presentations.md
@@ -4,7 +4,7 @@ slug: 'three-lessons-learned-from-overcoming-the-inertia-against-technical-prese
 draft: false
 publishDate: '2018-05-17'
 categories: ['Web Development']
-tags: ["Reflections"]
+tags: ["reflections"]
 ---
 > You don’t need to be an expert to teach others, even teaching people who have more overall experience than you do. The matter that someone has a wider breath of experience overall does not equate to knowing a particular system in depth.
 

--- a/content/posts/top-5-things-i-took-away-from-completing-100daysofcode/index.md
+++ b/content/posts/top-5-things-i-took-away-from-completing-100daysofcode/index.md
@@ -4,7 +4,7 @@ slug: 'top-5-things-i-took-away-from-completing-100daysofcode'
 draft: false
 publishDate: '2017-11-27'
 categories: ['Web Development']
-tags: ["Learning","Habit Building","Community"]
+tags: ["learning","habit-building","community"]
 series: ['100 Days of Code']
 ---
 ![Top 5 Things I took away from Completing #100DaysOfCode](images/2017-11-github-commits.jpg#center)

--- a/content/posts/top-5-things-i-took-away-from-completing-100daysofcode/index.md
+++ b/content/posts/top-5-things-i-took-away-from-completing-100daysofcode/index.md
@@ -3,7 +3,7 @@ title: 'Top 5 Things I took away from Completing #100DaysOfCode'
 slug: 'top-5-things-i-took-away-from-completing-100daysofcode'
 draft: false
 publishDate: '2017-11-27'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ["learning","habit-building","community"]
 series: ['100 Days of Code']
 ---

--- a/content/posts/top-5-things-i-took-away-from-completing-100daysofcode/index.md
+++ b/content/posts/top-5-things-i-took-away-from-completing-100daysofcode/index.md
@@ -3,7 +3,7 @@ title: 'Top 5 Things I took away from Completing #100DaysOfCode'
 slug: 'top-5-things-i-took-away-from-completing-100daysofcode'
 draft: false
 publishDate: '2017-11-27'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ["learning","habit-building","community"]
 series: ['100 Days of Code']
 ---

--- a/content/posts/typescript-utility-types-part-1-partial-pick-and-omit/index.md
+++ b/content/posts/typescript-utility-types-part-1-partial-pick-and-omit/index.md
@@ -3,7 +3,7 @@ title: 'TypeScript Utility Types Part 1: Partial, Pick, and Omit'
 slug: 'typescript-utility-types-part-1-partial-pick-and-omit'
 draft: false
 publishDate: '2020-04-27'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["TypeScript","TypeScript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---

--- a/content/posts/typescript-utility-types-part-1-partial-pick-and-omit/index.md
+++ b/content/posts/typescript-utility-types-part-1-partial-pick-and-omit/index.md
@@ -4,7 +4,7 @@ slug: 'typescript-utility-types-part-1-partial-pick-and-omit'
 draft: false
 publishDate: '2020-04-27'
 categories: ['Web Development']
-tags: ["typescript","typescript-generics"]
+tags: ["TypeScript","TypeScript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---
 ![TypeScript Utility Types Part 1: Partial, Pick, and Omit](images/compass-with-leather-notebook.jpg#center)

--- a/content/posts/typescript-utility-types-part-1-partial-pick-and-omit/index.md
+++ b/content/posts/typescript-utility-types-part-1-partial-pick-and-omit/index.md
@@ -4,7 +4,7 @@ slug: 'typescript-utility-types-part-1-partial-pick-and-omit'
 draft: false
 publishDate: '2020-04-27'
 categories: ['Web Development']
-tags: ["TypeScript","TypeScript Generics"]
+tags: ["typescript","typescript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---
 ![TypeScript Utility Types Part 1: Partial, Pick, and Omit](images/compass-with-leather-notebook.jpg#center)

--- a/content/posts/typescript-utility-types-part-2-record-readonly-required/index.md
+++ b/content/posts/typescript-utility-types-part-2-record-readonly-required/index.md
@@ -4,7 +4,7 @@ slug: 'typescript-utility-types-part-2-record-readonly-required'
 draft: false
 publishDate: '2020-05-04'
 categories: ['Web Development']
-tags: ["TypeScript","TypeScript Generics"]
+tags: ["typescript","typescript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---
 ![TypeScript Utility Types Part 2: Record, Readonly, & Required](images/reflective-architecture-perspective.jpg#center)

--- a/content/posts/typescript-utility-types-part-2-record-readonly-required/index.md
+++ b/content/posts/typescript-utility-types-part-2-record-readonly-required/index.md
@@ -3,7 +3,7 @@ title: 'TypeScript Utility Types Part 2: Record, Readonly, & Required'
 slug: 'typescript-utility-types-part-2-record-readonly-required'
 draft: false
 publishDate: '2020-05-04'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["TypeScript","TypeScript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---

--- a/content/posts/typescript-utility-types-part-2-record-readonly-required/index.md
+++ b/content/posts/typescript-utility-types-part-2-record-readonly-required/index.md
@@ -4,7 +4,7 @@ slug: 'typescript-utility-types-part-2-record-readonly-required'
 draft: false
 publishDate: '2020-05-04'
 categories: ['Web Development']
-tags: ["typescript","typescript-generics"]
+tags: ["TypeScript","TypeScript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---
 ![TypeScript Utility Types Part 2: Record, Readonly, & Required](images/reflective-architecture-perspective.jpg#center)

--- a/content/posts/typescript-utility-types-part-3-extract-exclude-and-nonnullable/index.md
+++ b/content/posts/typescript-utility-types-part-3-extract-exclude-and-nonnullable/index.md
@@ -3,7 +3,7 @@ title: 'TypeScript Utility Types Part 3: Extract, Exclude, and NonNullable'
 slug: 'typescript-utility-types-part-3-extract-exclude-and-nonnullable'
 draft: false
 publishDate: '2020-05-25'
-categories: ['Web Development']
+categories: ['Technical']
 tags: ["TypeScript","TypeScript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---

--- a/content/posts/typescript-utility-types-part-3-extract-exclude-and-nonnullable/index.md
+++ b/content/posts/typescript-utility-types-part-3-extract-exclude-and-nonnullable/index.md
@@ -4,7 +4,7 @@ slug: 'typescript-utility-types-part-3-extract-exclude-and-nonnullable'
 draft: false
 publishDate: '2020-05-25'
 categories: ['Web Development']
-tags: ["TypeScript","TypeScript Generics"]
+tags: ["typescript","typescript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---
 ![TypeScript Utility Types Part 3: Extract, Exclude, and NonNullable](images/intersecting-types.jpg#center)

--- a/content/posts/typescript-utility-types-part-3-extract-exclude-and-nonnullable/index.md
+++ b/content/posts/typescript-utility-types-part-3-extract-exclude-and-nonnullable/index.md
@@ -4,7 +4,7 @@ slug: 'typescript-utility-types-part-3-extract-exclude-and-nonnullable'
 draft: false
 publishDate: '2020-05-25'
 categories: ['Web Development']
-tags: ["typescript","typescript-generics"]
+tags: ["TypeScript","TypeScript-generics"]
 series: ["Diving into TypeScript Generics"]
 ---
 ![TypeScript Utility Types Part 3: Extract, Exclude, and NonNullable](images/intersecting-types.jpg#center)

--- a/content/posts/venturing-into-rabbit-holes/index.md
+++ b/content/posts/venturing-into-rabbit-holes/index.md
@@ -3,7 +3,7 @@ title: 'Venturing into Rabbit Holes'
 slug: 'venturing-into-rabbit-holes'
 draft: false
 publishDate: '2017-06-30'
-categories: ['Web Development']
+categories: ['Projects']
 tags: ['Projects']
 ---
 ![Twitch Viewer App](images/2017-06-twitch-v1-1.jpg)

--- a/content/posts/what-is-a-side-effect-anyway-30daysoffp-week-2/index.md
+++ b/content/posts/what-is-a-side-effect-anyway-30daysoffp-week-2/index.md
@@ -3,7 +3,7 @@ title: 'What is a Side Effect Anyway? - 30DaysofFP Week 2'
 slug: 'what-is-a-side-effect-anyway-30daysoffp-week-2'
 draft: false
 publishDate: '2019-08-19'
-categories: ['Learning & Challenges']
+categories: ['learning-and-challenges']
 tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/what-is-a-side-effect-anyway-30daysoffp-week-2/index.md
+++ b/content/posts/what-is-a-side-effect-anyway-30daysoffp-week-2/index.md
@@ -3,7 +3,7 @@ title: 'What is a Side Effect Anyway? - 30DaysofFP Week 2'
 slug: 'what-is-a-side-effect-anyway-30daysoffp-week-2'
 draft: false
 publishDate: '2019-08-19'
-categories: ['Web Development']
+categories: ['Learning & Challenges']
 tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---

--- a/content/posts/what-is-a-side-effect-anyway-30daysoffp-week-2/index.md
+++ b/content/posts/what-is-a-side-effect-anyway-30daysoffp-week-2/index.md
@@ -4,7 +4,7 @@ slug: 'what-is-a-side-effect-anyway-30daysoffp-week-2'
 draft: false
 publishDate: '2019-08-19'
 categories: ['Web Development']
-tags: ["Functional Programming"]
+tags: ["functional-programming"]
 series: ['30 Days of Functional Programming']
 ---
 ![What is a Side Effect Anyway? - 30DaysofFP Week 2](images/abstract-spiral-cannon-beach.jpg#center)

--- a/content/posts/what-mistakes-did-you-make-this-sprint/index.md
+++ b/content/posts/what-mistakes-did-you-make-this-sprint/index.md
@@ -4,7 +4,7 @@ slug: 'what-mistakes-did-you-make-this-sprint'
 draft: false
 publishDate: '2020-12-11'
 categories: ['General Musings']
-tags: ["Team Health","Psychological Safety","Retrospectives","Personal Growth","Agile and Scrum"]
+tags: ["team-health","psychological-safety","retrospectives","personal-growth","agile-and-scrum"]
 ---
 ![What Mistakes did you Make This Sprint?](images/together-painting.jpg#center)
 

--- a/content/posts/what-mistakes-did-you-make-this-sprint/index.md
+++ b/content/posts/what-mistakes-did-you-make-this-sprint/index.md
@@ -3,7 +3,7 @@ title: 'What Mistakes did you Make This Sprint?'
 slug: 'what-mistakes-did-you-make-this-sprint'
 draft: false
 publishDate: '2020-12-11'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["team-health","psychological-safety","retrospectives","personal-growth","agile-and-scrum"]
 ---
 ![What Mistakes did you Make This Sprint?](images/together-painting.jpg#center)

--- a/content/posts/who-are-we-excluding-in-our-systems-designs/index.md
+++ b/content/posts/who-are-we-excluding-in-our-systems-designs/index.md
@@ -4,7 +4,7 @@ slug: who-are-we-excluding-in-our-systems-designs
 draft: false
 publishDate: 2025-05-22
 categories: []
-tags: ["Accessibility", "Inclusion", "Ethics", "Systems Design", "AI"]
+tags: ["accessibility", "inclusion", "ethics", "systems-design", "ai"]
 ---
 {{< figure
   src="images/multicolored-containers.jpg"

--- a/content/posts/who-are-we-excluding-in-our-systems-designs/index.md
+++ b/content/posts/who-are-we-excluding-in-our-systems-designs/index.md
@@ -3,7 +3,7 @@ title: Who Are We Excluding in Our Systems Designs
 slug: who-are-we-excluding-in-our-systems-designs
 draft: false
 publishDate: 2025-05-22
-categories: []
+categories: ['Technical']
 tags: ["accessibility", "inclusion", "ethics", "systems-design", "AI"]
 ---
 {{< figure

--- a/content/posts/who-are-we-excluding-in-our-systems-designs/index.md
+++ b/content/posts/who-are-we-excluding-in-our-systems-designs/index.md
@@ -4,7 +4,7 @@ slug: who-are-we-excluding-in-our-systems-designs
 draft: false
 publishDate: 2025-05-22
 categories: []
-tags: ["accessibility", "inclusion", "ethics", "systems-design", "ai"]
+tags: ["accessibility", "inclusion", "ethics", "systems-design", "AI"]
 ---
 {{< figure
   src="images/multicolored-containers.jpg"

--- a/content/posts/you-cant-have-empathy-without-active-listening/index.md
+++ b/content/posts/you-cant-have-empathy-without-active-listening/index.md
@@ -3,7 +3,7 @@ title: "You Can't Have Empathy without Active Listening"
 slug: 'you-can-t-have-empathy-without-active-listening'
 draft: false
 publishDate: '2020-12-15'
-categories: ['General Musings']
+categories: ['Career Development']
 tags: ["psychological-safety"]
 ---
 ![You Can't Have Empathy without Active Listening](images/watch-listen-reflect-bench.jpg#center)

--- a/content/posts/you-cant-have-empathy-without-active-listening/index.md
+++ b/content/posts/you-cant-have-empathy-without-active-listening/index.md
@@ -4,7 +4,7 @@ slug: 'you-can-t-have-empathy-without-active-listening'
 draft: false
 publishDate: '2020-12-15'
 categories: ['General Musings']
-tags: ["Psychological Safety"]
+tags: ["psychological-safety"]
 ---
 ![You Can't Have Empathy without Active Listening](images/watch-listen-reflect-bench.jpg#center)
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -76,7 +76,7 @@
     {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
     <ul class="post-tags">
       {{- range ($.GetTerms $tags) }}
-      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      <li><a href="{{ .Permalink }}">{{ .LinkTitle | replaceRE "-" " " }}</a></li>
       {{- end }}
     </ul>
     {{- if (.Param "ShowPostNavLinks") }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -18,7 +18,7 @@
     {{- $count := .Count }}
     {{- with site.GetPage (printf "/%s/%s" $type $name) }}
     <li>
-        <a href="{{ .Permalink }}">{{ .Name }} <sup><strong><sup>{{ $count }}</sup></strong></sup> </a>
+        <a href="{{ .Permalink }}">{{ .LinkTitle | replaceRE "-" " " }} <sup><strong><sup>{{ $count }}</sup></strong></sup> </a>
     </li>
     {{- end }}
     {{- end }}


### PR DESCRIPTION
As a writer
I want to have a consistent approach to categorizing content
So that end users can discover topics of interest more readily.

## Implementation

* Overhaul tags to utilize kebab-case for better integration with Obsidian.
* Utilize Claude to review the previous category taxonomy and suggest a more nuanced breakdown of content.
* Utilize Claude to review all posts and suggest additional tags where applicable. Apply categories to posts which did not yet have a category.
* Update Claude documentation on how to handle categorizing content in the future to be more expedient and reference the existing taxonomy terms.