### PR TITLE
Add Comentario commenting system with theme integration

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -76,7 +76,7 @@ params:
   ShowPostNavLinks: true
   ShowAllPagesInArchive: true
   defaultTheme: dark
-  comments: true
+  comments: false
   editPost:
       URL: "https://github.com/entorenee/skyler-lemay-blog/blob/main/content"
       Text: "See a typo? Suggest a change in GitHub"

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -76,6 +76,7 @@ params:
   ShowPostNavLinks: true
   ShowAllPagesInArchive: true
   defaultTheme: dark
+  comments: true
   editPost:
       URL: "https://github.com/entorenee/skyler-lemay-blog/blob/main/content"
       Text: "See a typo? Suggest a change in GitHub"

--- a/config/production/hugo.yaml
+++ b/config/production/hugo.yaml
@@ -7,6 +7,7 @@ buildFuture: false
 
 params:
   env: production
+  comments: true
   services:
     umami_analytics:
       id: "98b882e2-1760-4639-bd20-eee629d534bd"

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,2 +1,27 @@
 <script defer src="https://comentario.culturegremlin.club/comentario.js"></script>
-<comentario-comments></comentario-comments>
+<comentario-comments id="comments-container"></comentario-comments>
+<script defer>
+  (function() {
+    function styleComments() {
+      const container = document.getElementById('comments-container')
+      const isSiteDarkTheme = document.body.classList.contains('dark');
+      const commentsTheme = isSiteDarkTheme ? 'dark' : 'light';
+      container.setAttribute('theme', commentsTheme);
+      }
+
+    // Load initially
+    styleComments();
+
+    // Listen for theme changes (only on body class changes)
+    const observer = new MutationObserver(mutations => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'class' && mutation.target === document.body) {
+          styleComments();
+          break;
+        }
+      }
+    });
+
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  })();
+</script>

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,2 @@
+<script defer src="https://comentario.culturegremlin.club/comentario.js"></script>
+<comentario-comments></comentario-comments>

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -1,35 +1,37 @@
 <div id="newsletter-container"></div>
 <script>
-  function loadNewsletter() {
-    const container = document.getElementById('newsletter-container');
-    container.innerHTML = '';
-    
-    const script = document.createElement('script');
-    script.async = true;
-    
-    if (document.body.classList.contains('dark')) {
-      script.setAttribute('data-uid', '99e00c99d5');
-      script.src = 'https://skyler-lemay.kit.com/99e00c99d5/index.js';
-    } else {
-      script.setAttribute('data-uid', 'b4c977bc68');
-      script.src = 'https://skyler-lemay.kit.com/b4c977bc68/index.js';
-    }
-    
-    container.appendChild(script);
-  }
-  
-  // Load initially
-  loadNewsletter();
-  
-  // Listen for theme changes (only on body class changes)
-  const observer = new MutationObserver(mutations => {
-    for (const mutation of mutations) {
-      if (mutation.attributeName === 'class' && mutation.target === document.body) {
-        loadNewsletter();
-        break;
+  (function() {
+    function loadNewsletter() {
+      const container = document.getElementById('newsletter-container');
+      container.innerHTML = '';
+
+      const script = document.createElement('script');
+      script.async = true;
+
+      if (document.body.classList.contains('dark')) {
+        script.setAttribute('data-uid', '99e00c99d5');
+        script.src = 'https://skyler-lemay.kit.com/99e00c99d5/index.js';
+      } else {
+        script.setAttribute('data-uid', 'b4c977bc68');
+        script.src = 'https://skyler-lemay.kit.com/b4c977bc68/index.js';
       }
+
+      container.appendChild(script);
     }
-  });
-  
-  observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
+    // Load initially
+    loadNewsletter();
+
+    // Listen for theme changes (only on body class changes)
+    const observer = new MutationObserver(mutations => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'class' && mutation.target === document.body) {
+          loadNewsletter();
+          break;
+        }
+      }
+    });
+
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  })();
 </script>


### PR DESCRIPTION
As an content writer
I want to enable comments support on the site
So that readers can directly engage with the content.

## Summary
• Add Comentario commenting system with theme-aware integration that adapts to dark/light mode
• Configure comments to be disabled in development and enabled in production environments

## Test plan
- [x] Verify comments are disabled in development mode
- [x] Verify comments are enabled in production mode  
- [x] Test theme switching updates comment widget appearance
- [x] Verify newsletter script continues working with IIFE wrapper

🤖 Generated with [Claude Code](https://claude.ai/code)