### PR TITLE
Add Buy Me a Coffee integration for reader support

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -48,6 +48,28 @@ body.dark pre.mermaid {
   }
 }
 
+.buy-me-a-coffee-wrapper {
+  margin: 1.5rem 0 2rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  p {
+    margin-bottom: 1rem;
+  }
+
+  .bmc-btn {
+    min-width: unset;
+    height: unset;
+    padding: 0.5rem 1rem;
+  }
+
+  .bmc-btn-text {
+    font-family: unset !important;
+    font-size: 18px;
+  }
+}
+
 #newsletter-container .formkit-form {
   border: 1px solid var(--border);
   border-radius: var(--radius);

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -91,6 +91,8 @@ params:
       I am also an endurance athlete, having cycled over 10,000km in 2024. As an openly trans and neurodivergent human, my writing is informed by my intersectional identity navigating the world. I passionately engage in universal design discussions across many aspects of life, including work.
 
   socialIcons:
+    - name: buymeacoffee
+      url: https://buymeacoffee.com/skylerlemay
     - name: github
       url: https://github.com/entorenee
     - name: linkedin

--- a/content/posts/exciting-updates-to-the-site.md
+++ b/content/posts/exciting-updates-to-the-site.md
@@ -1,0 +1,21 @@
+---
+title: 'Exciting Updates to the Site'
+summary: 'Updates to the site including comments via Comentario, newsletter enhancements, Buy Me a Coffee support, and privacy-focused Umami analytics—all built on FOSS principles.'
+description: 'Recent site improvements including self-hosted commenting system, newsletter functionality, optional support platform, and privacy-compliant analytics using open source solutions.'
+slug: 'exciting-updates-to-the-site'
+draft: false
+publishDate: '2025-06-07'
+categories: ['technical']
+tags: ['tooling', 'hugo', 'ethics', 'community']
+---
+This will be a quick and short post I promise. I have loved the sudden surge of creative energy these past few weeks. This also includes some updates to the site and ways people can interact if they so desire. I'm also a big proponent of upfront and transparent communication, which plays into several of the items.
+
+First off, there is now support for comments on posts thanks to a a Free and Open Source Software (FOSS) called [Comentario](https://gitlab.com/comentario/comentario). Currently the only means of logging in is by creating an account. If there is interest, I can also add support for single sign-on providers. Right now it's an idea on the back burner, but the software does support it. For those privacy minded folx, the entire setup is self-hosted on a local server I manage and expose via Cloudflare tunnels. My main ask is that people be kind and empathetic if they choose to leave comments. There is always the option of replying to any newsletter email as well.
+
+Speaking of newsletter, I've been leveraging it to send emails to people when posts go live as well as a weekly digest. You have the option to adjust those subscription settings on your own if you only prefer one of the options. I won't send you spam and absolutely will not sell any list data. The weekly digest includes extra goodies that aren't really worth a full blog post. That could include: random idiomatic expressions that don't make sense to my neurodivergent brain, books I've read, or other random tidbits.
+
+Most recently. I've added a way for people to optionally support my work if you feel so inclined. This utilizes the [Buy Me a Coffee](https://buymeacoffee.com/skylerlemay) platform, which is similar to Patreon, but has better support for one-off donations instead of focusing on different tiers. There's a small block of text at the end of each page and a link on the homepage. I was wavering on this, but after some discussion and encouragement from a few friends, I decided to make the option available. Writing takes time, averaging 6 hours a week, not including general research and reading I'm already doing. I have no desire to ever implement a paywall or advertising. Those deeply conflict with my anticapitalistic views and preference towards mutual aid. If you appreciate things you have read and would like to support me, I'd be delighted if you would consider using this service. For clarification it isn't a literal coffee, but a representation of monetary value. 
+
+The last update is also more likely of interest to any privacy minded folx. It's helpful to have analytics. At the same time, Google is a pretty wretched company when it comes to privacy and is a hard no for me. After some research and exploration, I found another FOSS option that is lightweight, private, and compliant with GDPR and CCPA. [Umami](https://umami.is/features)—interesting name I know—anonymizes user data, doesn't utilize cookies, and also allows self hosting as an option. This allows capturing and reviewing helpful analytics, without all the creepy lack of privacy implications.
+
+It's been a busy 2 weeks working on different feature development in the background in addition to the typical content. Thank you to everyone who has read and shared what I've written so far. I have a growing pile of topics in the brainstorm queue. I'll conclude with a semi-related thought, if you are curious of how I landed on the name behind the site and the implications of it, let me know in any of the various mediums mentioned above.

--- a/content/posts/exciting-updates-to-the-site.md
+++ b/content/posts/exciting-updates-to-the-site.md
@@ -1,7 +1,6 @@
 ---
 title: 'Exciting Updates to the Site'
 summary: 'Updates to the site including comments via Comentario, newsletter enhancements, Buy Me a Coffee support, and privacy-focused Umami analytics—all built on FOSS principles.'
-description: 'Recent site improvements including self-hosted commenting system, newsletter functionality, optional support platform, and privacy-compliant analytics using open source solutions.'
 slug: 'exciting-updates-to-the-site'
 draft: false
 publishDate: '2025-06-07'

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -70,6 +70,7 @@
     </div>
   {{- end -}}
 
+  {{- partial "buy_me_a_coffee.html" . -}}
   {{- partial "newsletter.html" -}}
 
   <footer class="post-footer">

--- a/layouts/partials/buy_me_a_coffee.html
+++ b/layouts/partials/buy_me_a_coffee.html
@@ -1,0 +1,5 @@
+<hr>
+<div class="buy-me-a-coffee-wrapper">
+  <p>Writing without a paywall or gross internet tracking ads is important to me, but writing these posts does take time. If you have enjoyed this post and others, I'd be delighted if you consider buying me a coffee! It's a low friction means to support my work on a one-off or recurring basis. 💜</p>
+  <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="skylerlemay" data-color="#5928a3" data-emoji="" data-font="Arial" data-text="Buy me a coffee" data-outline-color="#ffffff" data-font-color="#ffffff" data-coffee-color="#FFDD00" ></script>
+</div>


### PR DESCRIPTION
## Summary
• Add Buy Me a Coffee donation buttons to homepage and individual blog posts to enable readers to support the blog
• Include announcement post explaining the new support option and its purpose

## Test plan
- [x] Verify coffee button displays correctly on homepage
- [x] Verify coffee button displays correctly on individual blog posts  
- [x] Test button functionality and link behavior
- [x] Confirm announcement post renders properly
- [x] Check responsive design on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)